### PR TITLE
Check if mongoDB authentication is required.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,20 +24,23 @@ config.mongodb = {};
 //
 // `mongodb.connectOptions` will override any specified in the URL.
 //
-// format: mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+// format: mongodb://[username:password@]host1[:port1][,host2[:port2],
+// ...[,hostN[:portN]]][/[database][?options]]
 //
-//config.mongodb.url = 'mongodb://localhost:27017/bedrock_dev';
+// config.mongodb.url = 'mongodb://localhost:27017/bedrock_dev';
 config.mongodb.name = 'bedrock_dev';
 config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
 config.mongodb.username = 'bedrock';
 config.mongodb.password = 'password';
 config.mongodb.adminPrompt = true;
+// always authenticate to mongodb even when auth is not required by mongodb
+config.mongodb.forceAuthentication = false;
 config.mongodb.authentication = {
   // used by MongoDB >= 3.0
-  //authMechanism: 'SCRAM-SHA-1'
+  // authMechanism: 'SCRAM-SHA-1'
   // used by MongoDB < 3.0
-  //authMechanism: 'MONGODB-CR'
+  // authMechanism: 'MONGODB-CR'
 };
 config.mongodb.connectOptions = {
   db: {
@@ -71,7 +74,7 @@ config.mongodb.options = {
 // node.
 config.mongodb.local = {};
 config.mongodb.local.enable = false;
-//config.mongodb.local.url = 'mongodb://localhost:27017/local';
+// config.mongodb.local.url = 'mongodb://localhost:27017/local';
 config.mongodb.local.name = 'local';
 config.mongodb.local.collection = 'bedrock_dev';
 config.mongodb.local.writeOptions = {

--- a/lib/database.js
+++ b/lib/database.js
@@ -651,11 +651,29 @@ function _openDatabase(options, callback) {
     connect: function(callback) {
       _connect(options, callback);
     },
+    checkAuthRequired: ['connect', function(callback, results) {
+      if(config.forceAuthentication) {
+        return callback(null, true);
+      }
+      var db = results.connect;
+      var authRequired = false;
+      db.admin().listDatabases(function(err) {
+        // if an authorization error is returned, authorization is required
+        if(err && err.code === 13) {
+          authRequired = true;
+          return callback(null, authRequired);
+        }
+        callback(err, authRequired);
+      });
+    }],
     serverInfo: ['connect', function(callback, results) {
       db = results.connect;
       db.admin().serverInfo(callback);
     }],
-    auth: ['serverInfo', function(callback, results) {
+    auth: ['serverInfo', 'checkAuthRequired', function(callback, results) {
+      if(!results.checkAuthRequired) {
+        return callback(null, 'NotRequired');
+      }
       var username = config.username;
       var password = config.password;
       var opts = config.authentication;
@@ -668,7 +686,11 @@ function _openDatabase(options, callback) {
       opts = bedrock.util.extend({}, opts, {authdb: db.databaseName});
       db.authenticate(username, password, opts, callback);
     }],
-    authSuccess: ['auth', function(callback) {
+    authSuccess: ['auth', function(callback, results) {
+      if(results.auth === 'NotRequired') {
+        logger.debug('database authentication not required');
+        return callback();
+      }
       logger.debug('database authentication succeeded: db=' + config.name +
         ' username=' + config.username);
       callback();


### PR DESCRIPTION
The use case for this feature is automated testing where authentication is not enabled on the mongoDB server.  The admin prompt for creating the `bedrock` user is avoided.  There is no need to create mongoDB user accounts under these conditions.