### PR TITLE
Replace deprecated `ensureIndex` with `createIndex`.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -16,7 +16,7 @@
  * is exposed by this module as 'localDocumentId'. The value of 'local' is
  * a JSON object where local properties should be stored.
  *
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
 var async = require('async');
 var crypto = require('crypto');
@@ -351,7 +351,7 @@ api.buildUpdate = function(obj) {
  */
 api.createIndexes = function(options, callback) {
   async.each(options, function(item, callback) {
-    api.collections[item.collection].ensureIndex(
+    api.collections[item.collection].createIndex(
       item.fields, item.options, callback);
   }, callback);
 };
@@ -498,7 +498,7 @@ function _setupLocalDatabase(callback) {
       api.localCollection = collection;
 
       // create index
-      api.localCollection.ensureIndex(
+      api.localCollection.createIndex(
         {id: true}, {unique: true, background: true}, function(err) {
           callback(err);
         });

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
 var async = require('async');
 var mongo = require('mongodb');

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -1,7 +1,7 @@
 /*
  * Bedrock mongodb test configuration.
  *
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
 var config = require('bedrock').config;
 


### PR DESCRIPTION
Fixes #6.

This has been tested against top level issuer and IdP test suites.  No issues detected.