### PR TITLE
Reconnect to MongoDB server on connection failure.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,7 +48,12 @@ config.mongodb.connectOptions = {
     journal: true
   },
   server: {
-    auto_reconnect: true
+    socketOptions: {
+      autoReconnect: true, // reconnect on connection failure
+      keepAlive: 15000, // TCP keep-alive every 15 seconds (useful for VPN'd connections)
+    },
+    reconnectInterval: 1000, // attempt reconnect every second
+    reconnectTries: 604800, // attempt to reconnect for a week and then give up
   },
   replSet: {},
   mongos: {}


### PR DESCRIPTION
Aseta was not reconnecting until I change the reconnect settings to the following. I also enabled TCP keep-alive, to fix a bug that kept cropping up where the TCP connection dies when the database is locked for too long (like during a backup). Reconnect + TCP keep alive seems to have dealt with the problem.