### PR TITLE
Add server version check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-mongodb ChangeLog
 
+### Added
+- Ability to check the server version via the semver-style version string
+  located in the `bedrock.config.mongodb.requirements.serverVersion` config
+  key.
+
 ## 5.0.1 2018-02-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For documentation on database configuration, see [config.js](./lib/config.js).
 ## Requirements
 
 * Linux or Mac OS X (also works on Windows with some coaxing)
-* node.js >= 4.x.x
+* node.js >= 6.x.x
 * npm >= 1.4.x
 * mongodb ~= 3.x
 * libkrb5-dev >= 1.x.x

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,3 +78,7 @@ config.mongodb.local.writeOptions = {
   j: true,
   multi: true
 };
+
+config.mongodb.requirements = {};
+// server version requirement with server-style string
+config.mongodb.requirements.serverVersion = '>=3.0';

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,12 +21,13 @@
 'use strict';
 
 const async = require('async');
+const bedrock = require('bedrock');
 const blake2 = require('blake2');
 const crypto = require('crypto');
-const mongo = require('mongodb');
-const bedrock = require('bedrock');
 const logger = require('./logger');
+const mongo = require('mongodb');
 const mongodbUri = require('mongodb-uri');
+const semver = require('semver');
 const BedrockError = bedrock.util.BedrockError;
 
 // load config defaults
@@ -627,7 +628,30 @@ function _openDatabase(options, callback) {
   let db;
   async.auto({
     connect: callback => _connect(options, callback),
-    checkAuthRequired: ['connect', (results, callback) => {
+    serverInfo: ['connect', (results, callback) => {
+      db = results.connect;
+      db.admin().serverInfo(callback);
+    }],
+    serverCheck: ['serverInfo', (results, callback) => {
+      const version = results.serverInfo.version;
+      logger.info('connected to database', {
+        url: config.url,
+        version: version
+      });
+      if(config.requirements.serverVersion) {
+        if(!semver.satisfies(version, config.requirements.serverVersion)) {
+          return callback(new BedrockError(
+            'Unsupported database version.',
+            'DatabaseError', {
+              url: config.url,
+              version: version,
+              required: config.requirements.serverVersion
+            }));
+        }
+      }
+      callback(null, true);
+    }],
+    checkAuthRequired: ['connect', 'serverCheck', (results, callback) => {
       if(config.forceAuthentication) {
         return callback(null, true);
       }
@@ -641,10 +665,6 @@ function _openDatabase(options, callback) {
         }
         callback(err, authRequired);
       });
-    }],
-    serverInfo: ['connect', (results, callback) => {
-      db = results.connect;
-      db.admin().serverInfo(callback);
     }],
     auth: ['serverInfo', 'checkAuthRequired', (results, callback) => {
       if(!results.checkAuthRequired) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "mongodb": "~2.2.31",
     "mongodb-uri": "^0.9.7",
     "progress": "~1.1.8",
-    "prompt": "~0.2.14"
+    "prompt": "~0.2.14",
+    "semver": "^5.5.0"
   },
   "peerDependencies": {
     "bedrock": "^1.0.0"


### PR DESCRIPTION
- Use `bedrock.config.mongodb.requirements.serverVersion` config key with
  a semver-style version string..
- Check done before auth check to avoid possible errors with closed
  connections. May need to be revisited.