### PR TITLE
Rollback createIndexes changes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -345,15 +345,10 @@ api.buildUpdate = function(obj) {
  *          fields: <collection_fields>,
  *          options: <index_options>
  * @param callback(err) called once the operation completes.
- *
- * @returns a Promise that resolves to the result of the operation.
  */
-api.createIndexes = callbackify(async (options) => {
-  assert.array(options, 'options');
-  const promises = options.map(item => api.collections[item.collection]
-    .createIndex(item.fields, item.options));
-  return Promise.all(promises);
-});
+api.createIndexes = (options, callback) => async.each(
+  options, (item, callback) => api.collections[item.collection].createIndex(
+    item.fields, item.options, callback), callback);
 
 /**
  * Creates a streaming GridFS bucket instance.


### PR DESCRIPTION
It appears that `bedrock.util.callbackify` is not compatible with `async.waterfall`

This throws `callback is not a function` https://github.com/digitalbazaar/bedrock-jobs/blob/master/lib/index.js#L65

I don't want to go down this rabbit hole at this time.