### PR TITLE
Use sha256 in database.hash API.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,6 @@ const logger = require('./logger');
 const mongo = require('mongodb');
 const mongodbUri = require('mongodb-uri');
 const semver = require('semver');
-const sodium = require('sodium-native');
 const {BedrockError} = bedrock.util;
 
 // load config defaults
@@ -262,9 +261,9 @@ api.hash = key => {
       'Invalid key given to database hash method.',
       'InvalidKey', {key});
   }
-  const hashBuffer = Buffer.allocUnsafe(32);
-  sodium.crypto_generichash(hashBuffer, Buffer.from(key, 'utf8'));
-  return hashBuffer.toString('base64');
+  const md = crypto.createHash('sha256');
+  md.update(key, 'utf8');
+  return md.digest('base64');
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "mongodb-uri": "^0.9.7",
     "progress": "~1.1.8",
     "prompt": "~0.2.14",
-    "semver": "^5.5.0",
-    "sodium-native": "^2.2.3"
+    "semver": "^5.5.0"
   },
   "peerDependencies": {
     "bedrock": "^1.11.0"


### PR DESCRIPTION
This eliminates sodium-native dep which is a step towards getting bedrock apps to run with node 12.

This switches database has to `sha256`.  It happens that hardware with [SHA Intrinsics](https://gist.github.com/mattcollier/8081d07b8014a53937d8219f6b4a2843) outperforms blake2b as well.