### PR TITLE
Update required server version to >=4.2.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        mongodb-version: ['3.6', '4.0', '4.2']
+        mongodb-version: ['4.2']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Changed
 - **BREAKING**: Update to `mongodb` 3.5 node driver.
+- **BREAKING**: Set default server version requirement to ">=4.2".
+  - This requirement can be adjusted with the
+    `config.mongodb.requirements.serverVersion` config value.
 - GitHub actions now tests Node.js versions 10, 12, and 14.
-- GitHub actions now tests mongodb versions 3.6, 4.0, and 4.2.
+- GitHub actions now tests mongodb version 4.2.
 - **BREAKING** autoReconnect is now `false` and should not be `true`.
 - `runOnceAsync` has been changed to `runOnce`.
 - Db no longer contains methods that are Mongo 3.5 client specific.

--- a/lib/config.js
+++ b/lib/config.js
@@ -84,4 +84,4 @@ config.mongodb.local.writeOptions = {
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string
-config.mongodb.requirements.serverVersion = '>=3.0';
+config.mongodb.requirements.serverVersion = '>=4.2';

--- a/test/test.js
+++ b/test/test.js
@@ -5,4 +5,4 @@ const bedrock = require('bedrock');
 require('bedrock-mongodb');
 
 require('bedrock-test');
-bedrock.start();
+bedrock.start().catch(err => console.error(err));


### PR DESCRIPTION
- Only test with 4.2.
- Keeping mongo version matrix to more easily add new versions.

Based on comment: https://github.com/digitalbazaar/bedrock-mongodb/pull/33#discussion_r434886994