### PR TITLE
Do not set db if no client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-mongodb ChangeLog
 
+## 7.0.1 -
+
+### Changed
+- Add a check to ensure connection errors are passed to the callback.
+
 ## 7.0.0 - 2020-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Changed
 - Add a check to ensure connection errors are passed to the callback.
 
+### Added
+- Added an auth object to connectOptions if config.username & password are set.
+- Added a `useNewUrlParser` option to config.
+
 ## 7.0.0 - 2020-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-mongodb ChangeLog
 
-## 7.0.1 -
+## 7.1.0 -
 
 ### Changed
 - Add a check to ensure connection errors are passed to the callback.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ connectOptions.tls = true;
 // the `authSource` option replaces the older `authDB` option
 // it should be specified or else it will be the `mongodb.name`
 connectOptions.authSource = 'my_provider_auth_db'; 
-connectOptions.authSource = 'admin';
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const {config} = require('bedrock');
 config.mongodb.username = 'me';
 config.mongodb.password = 'password';
 const {connectOptions} = config.mongodb;
-// this optional and only required if connecting to a replicaSet
+// optional, only required if connecting to a replicaSet
 connectOptions.replicaSet = 'my_provider_replica_set';
 // optional, but required in production by many providers
 connectOptions.ssl = true;

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ bedrock.config.mongodb.host = 'localhost';      // default: localhost
 bedrock.config.mongodb.port = 27017;            // default: 27017
 bedrock.config.mongodb.username = 'my_project'; // default: bedrock
 bedrock.config.mongodb.password = 'password';   // default: password
-bedrock.config.mongodb.connectOptions.authSource = 'admin'; // default: bedrock_dev
 
 // the mongodb database 'my_project_dev' and the 'my_project' user will
 // be created on start up following a prompt for the admin user credentials
@@ -68,13 +67,18 @@ For documentation on database configuration, see [config.js](./lib/config.js).
 ### Connecting and Authenticating
 MongoDB's documentation offers tons of great examples on how to authenticate
 using a myriad number of connection strings.
+
 [Mongo Node 3.5 Driver connect docs](http://mongodb.github.io/node-mongodb-native/3.5/tutorials/connect/)
+
 [Mongo Node 3.5 Driver atlas docs](https://docs.mongodb.com/drivers/node#connect-to-mongodb-atlas)
 
 You can also connect to access-enabled mongo servers using some small changes to the
 `config.mongodb.connectOptions`:
 ```js
-const {connectOptions} = bedrock.config.mongodb;
+const {config} = require('bedrock');
+config.mongodb.username = 'me';
+config.mongodb.password = 'password';
+const {connectOptions} = config.mongodb;
 // this optional and only required if connecting to a replicaSet
 connectOptions.replicaSet = 'my_provider_replica_set';
 // optional, but required in production by many providers
@@ -83,6 +87,8 @@ connectOptions.ssl = true;
 connectOptions.tls = true;
 // the `authSource` option replaces the older `authDB` option
 connectOptions.authSource: 'my_provider_auth_db'; 
+// an authSource should be specified else it will be the `mongodb.name`
+connectOptions.authSource = 'admin';
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -123,46 +123,6 @@ Creates and returns a new `GridFSBucket` from the native driver. Options are
 the same as for `GridFSBucket`. The current client is used and the
 `writeConcern` option defaults to the `writeOptions` config value.
 
-### getDistributedIdGenerator(namespace, callback)
-
-Gets the `DistributedIdGenerator` for the given namespace. If the
-`DistributedIdGenerator` does not exist, it will be created. The `callback`
-will be passed an error if one occurred, otherwise it will be passed `null`
-for the error and the `DistributedIdGenerator` instance. A
-`DistributedIdGenerator` can be used to quickly generate unique identifiers
-in a safe and distributed manner.
-
-The underlying assumption that prevents identifier collisions is that there is
-a shared collection (amongst all machines) with synchronized write access. To
-ensure identifiers can be generated without waiting for a system-wide lock,
-this collection is only hit once a local identifier namespace is exhausted,
-which should be very rare.
-
-A distributed ID looks like:
-
-```
-<version>.<globalId>.<localId>.<currentId>
-```
-
-Where '.' is the reserved separator character. The `globalId` is stored
-in a shared database and can only be updated atomically.
-
-The version is hardcoded to 1. The `localId` can be any combination of
-alphanumeric characters not including `.`. The `.` character was chosen
-instead of `-` or `_` because those characters are used in URL-safe base64
-encodings. This allows `globalId` and `localId` parts to be encoded in base64,
-however, they are encoded in hex in the current implementation as is the
-`currentId`.
-
-### DistributedIdGenerator.generateId(callback)
-
-Generates a new unique, URL-safe identifier. The identifier is guaranteed
-not to conflict with any other identifier generated using the same namespace,
-regardless of the machine used to generate it (provided that the machines
-share the same database). If an error occurs, the `callback` will be called
-with the error, otherwise, it will be called with `null` for the error and
-the identifier.
-
 ## Test Mode
 ### Drop Collections on Initialization
 When doing testing, it is often desirable to have empty collections at the
@@ -185,4 +145,4 @@ bedrock.config.mongodb.dropCollections.collections = [];
 ```
 
 [bedrock]: https://github.com/digitalbazaar/bedrock
-[mongodb-native]: http://mongodb.github.io/node-mongodb-native/2.0/
+[mongodb-native]: http://mongodb.github.io/node-mongodb-native/3.5/

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ connectOptions.ssl = true;
 // optional, only required if your provider requires tls 
 connectOptions.tls = true;
 // the `authSource` option replaces the older `authDB` option
-connectOptions.authSource: 'my_provider_auth_db'; 
-// an authSource should be specified else it will be the `mongodb.name`
+// it should be specified or else it will be the `mongodb.name`
+connectOptions.authSource = 'my_provider_auth_db'; 
 connectOptions.authSource = 'admin';
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const {connectOptions} = config.mongodb;
 connectOptions.replicaSet = 'my_provider_replica_set';
 // optional, but required in production by many providers
 connectOptions.ssl = true;
-// optional but required is your provider requires tls 
+// optional, only required if your provider requires tls 
 connectOptions.tls = true;
 // the `authSource` option replaces the older `authDB` option
 connectOptions.authSource: 'my_provider_auth_db'; 

--- a/README.md
+++ b/README.md
@@ -60,29 +60,29 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
 bedrock.start();
 ```
 
-Below is an example demonstrating the use of a distributed ID generator.
-
-```js
-var database = require('bedrock-mongodb');
-
-database.getDistributedIdGenerator('mynamespace', function(err, idGenerator) {
-  if(err) {
-    console.error('Error', err);
-    return;
-  }
-  idGenerator.generateId(function(err, id) {
-    if(err) {
-      console.error('Error', err);
-      return;
-    }
-    console.log('ID generated', identifier);
-  });
-});
-```
-
 ## Configuration
 
 For documentation on database configuration, see [config.js](./lib/config.js).
+
+### Connecting and Authenticating
+MongoDB's documentation offers tons of great examples on how to authenticate
+using a myriad amount of connection strings.
+[Mongo Node 3.5 Driver connect docs](http://mongodb.github.io/node-mongodb-native/3.5/tutorials/connect/)
+[Mongo Node 3.5 Driver atlas docs](https://docs.mongodb.com/drivers/node#connect-to-mongodb-atlas)
+
+You can also connect to access-enabled mongo servers using some small changes to the
+`config.mongodb.connectOptions`:
+```js
+const {connectOptions} = bedrock.mongodb;
+// this optional and only required if connecting to a replicaSet
+connectOptions.replicaSet = process.env.mongo_replicaSet;
+// if you use srv in your connection string you do not need to set ssl
+connectOptions.ssl = true,
+// this is new and should be user over username and password
+connectOptions.auth = { user: process.env.mongo_user, password: process.env.mongo_password },
+// this was previously call authDB
+connectOptions.authSource: process.env.mongo_authdb || 'admin'
+```
 
 ## Requirements
 
@@ -96,7 +96,7 @@ For documentation on database configuration, see [config.js](./lib/config.js).
 
 1. Ensure an admin user is set up on mongodb. To do so, follow the instructions
    at [mongodb.org](http://docs.mongodb.org/manual/tutorial/add-user-administrator/)
-   for your version of MongoDB. Version 3.x is currently supported.
+   for your version of MongoDB. Version 4.2.x is currently supported.
 2. [optional] Tweak your project's configuration settings; see
    [Configuration](#configuration) or [Quick Examples](#quickexamples).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For documentation on database configuration, see [config.js](./lib/config.js).
 
 ### Connecting and Authenticating
 MongoDB's documentation offers tons of great examples on how to authenticate
-using a myriad amount of connection strings.
+using a myriad number of connection strings.
 [Mongo Node 3.5 Driver connect docs](http://mongodb.github.io/node-mongodb-native/3.5/tutorials/connect/)
 [Mongo Node 3.5 Driver atlas docs](https://docs.mongodb.com/drivers/node#connect-to-mongodb-atlas)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const {connectOptions} = bedrock.mongodb;
 connectOptions.replicaSet = process.env.mongo_replicaSet;
 // you must set `ssl` unless `srv` is present in your connection string (in which case, don't set it)
 connectOptions.ssl = true,
-// this is new and should be user over username and password
+// `auth` should now be used instead of older options `username` and `password`
 connectOptions.auth = { user: process.env.mongo_user, password: process.env.mongo_password },
 // the `authSource` option replaces the older `authDB` option
 connectOptions.authSource: process.env.mongo_authdb || 'admin'

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ connectOptions.replicaSet = process.env.mongo_replicaSet;
 connectOptions.ssl = true,
 // this is new and should be user over username and password
 connectOptions.auth = { user: process.env.mongo_user, password: process.env.mongo_password },
-// this was previously call authDB
+// the `authSource` option replaces the older `authDB` option
 connectOptions.authSource: process.env.mongo_authdb || 'admin'
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ bedrock.config.mongodb.host = 'localhost';      // default: localhost
 bedrock.config.mongodb.port = 27017;            // default: 27017
 bedrock.config.mongodb.username = 'my_project'; // default: bedrock
 bedrock.config.mongodb.password = 'password';   // default: password
+bedrock.config.mongodb.connectOptions.authSource = 'admin'; // default: bedrock_dev
 
 // the mongodb database 'my_project_dev' and the 'my_project' user will
 // be created on start up following a prompt for the admin user credentials
@@ -73,15 +74,15 @@ using a myriad number of connection strings.
 You can also connect to access-enabled mongo servers using some small changes to the
 `config.mongodb.connectOptions`:
 ```js
-const {connectOptions} = bedrock.mongodb;
+const {connectOptions} = bedrock.config.mongodb;
 // this optional and only required if connecting to a replicaSet
-connectOptions.replicaSet = process.env.mongo_replicaSet;
-// you must set `ssl` unless `srv` is present in your connection string (in which case, don't set it)
-connectOptions.ssl = true,
-// `auth` should now be used instead of older options `username` and `password`
-connectOptions.auth = { user: process.env.mongo_user, password: process.env.mongo_password },
+connectOptions.replicaSet = 'my_provider_replica_set';
+// optional, but required in production by many providers
+connectOptions.ssl = true;
+// optional but required is your provider requires tls 
+connectOptions.tls = true;
 // the `authSource` option replaces the older `authDB` option
-connectOptions.authSource: process.env.mongo_authdb || 'admin'
+connectOptions.authSource: 'my_provider_auth_db'; 
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also connect to access-enabled mongo servers using some small changes to
 const {connectOptions} = bedrock.mongodb;
 // this optional and only required if connecting to a replicaSet
 connectOptions.replicaSet = process.env.mongo_replicaSet;
-// if you use srv in your connection string you do not need to set ssl
+// you must set `ssl` unless `srv` is present in your connection string (in which case, don't set it)
 connectOptions.ssl = true,
 // this is new and should be user over username and password
 connectOptions.auth = { user: process.env.mongo_user, password: process.env.mongo_password },

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,8 +33,8 @@ config.mongodb = {};
 config.mongodb.name = 'bedrock_dev';
 config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
-config.mongodb.username = 'bedrock';
-config.mongodb.password = 'password';
+config.mongodb.username = undefined;
+config.mongodb.password = undefined;
 config.mongodb.adminPrompt = true;
 // always authenticate to mongodb even when auth is not required by mongodb
 config.mongodb.forceAuthentication = false;

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,7 +49,8 @@ config.mongodb.connectOptions = {
   j: true,
   useUnifiedTopology: true,
   serverSelectionTimeoutMS: 30000,
-  autoReconnect: false
+  autoReconnect: false,
+  useNewUrlParser: true,
 };
 config.mongodb.writeOptions = {
   j: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -715,7 +715,7 @@ function _connect(options, callback) {
       password: config.password
     };
     // authSource is the database to authenticate against
-    // this is usually admin in dev and a specific db in production
+    // this is usually `admin` in dev and a specific db in production
     connectOptions.authSource = config.connectOptions.authSource || config.name;
   }
   MongoClient.connect(options.url, connectOptions, (err, client) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -713,8 +713,10 @@ function _connect(options, callback) {
     if(!err && !options.init) {
       logger.info('connecting to database: ' + options.url);
     }
-    // http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html#db
-    const db = client.db(config.name);
+    let db = null;
+    if(client) {
+      db = client.db(config.name);
+    }
     callback(err, {db, client});
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -672,9 +672,10 @@ function _openDatabase(options, callback) {
       if(_usesRoles(results.serverInfo)) {
         auth.authdb = config.name;
         // authenticate against shared db
-        opts = {...opts, authSource: config.name};
+        opts.authSource = config.connectOptions.authSource || config.name;
         return _loginUser({server, opts, auth, callback});
       }
+      // FIXME this code will never be called because serverVersion is 4.2
       // backwards-compatible mode; auth using opened db
       opts = {...opts, authSource: db.databaseName};
       auth.authdb = db.databaseName;
@@ -699,7 +700,7 @@ function _connect(options, callback) {
     logger.info('connecting to database: ' + options.url);
   }
 
-  let connectOptions = config.connectOptions;
+  let connectOptions = {...config.connectOptions};
 
   // convert legacy connect options
   if('socketOptions' in config.connectOptions) {
@@ -714,8 +715,8 @@ function _connect(options, callback) {
       password: config.password
     };
     // authSource is the database to authentication against
-    // this is usually admin
-    connectOptions.authSource = connectOptions.authSource || 'admin';
+    // this is usually admin in dev and a specific db in production
+    connectOptions.authSource = config.connectOptions.authSource || config.name;
   }
   MongoClient.connect(options.url, connectOptions, (err, client) => {
     if(!err && !options.init) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,6 +172,7 @@ function init(callback) {
         options: {unique: true, background: true}
       }], callback)],
     setupLocal: ['openLocal', (results, callback) => {
+console.log('setupLocal', results);
       // setup machine-local (non-replicated) database
       api.localClient = results.openLocal;
       if(!results.openLocal) {
@@ -649,6 +650,7 @@ function _openDatabase(options, callback) {
       }
       const db = results.connect.db;
       let authRequired = false;
+console.log('listDatabases called');
       db.admin().listDatabases(null, err => {
         // if an authorization error is returned, authorization is required
         if(err && err.code === 13) {
@@ -668,7 +670,7 @@ function _openDatabase(options, callback) {
         password: config.password
       };
       let opts = {...config.authentication, ...config.connectOptions};
-      const server = new Server(config.host, config.port);
+      const server = new Server(config.host, config.port, opts);
       if(_usesRoles(results.serverInfo)) {
         auth.authdb = config.name;
         // authenticate against shared db
@@ -733,6 +735,7 @@ function _connect(options, callback) {
  * @returns {Promise} The result of the connect.
 */
 async function _loginUser({auth, opts, callback, server}) {
+console.log('_loginUser', {auth, opts, callback, server});
   const client = new MongoClient(server, {
     auth,
     ...opts

--- a/lib/index.js
+++ b/lib/index.js
@@ -714,7 +714,7 @@ function _connect(options, callback) {
       user: config.username,
       password: config.password
     };
-    // authSource is the database to authentication against
+    // authSource is the database to authenticate against
     // this is usually admin in dev and a specific db in production
     connectOptions.authSource = config.connectOptions.authSource || config.name;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,8 +76,8 @@ api.localDocumentId = 'local';
 api.writeOptions = bedrock.config.mongodb.writeOptions;
 api.localWriteOptions = bedrock.config.mongodb.local.writeOptions;
 
--// load test config
--bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
+// load test config
+bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
 
 bedrock.events.on('bedrock.init', promisify(init));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,8 +76,8 @@ api.localDocumentId = 'local';
 api.writeOptions = bedrock.config.mongodb.writeOptions;
 api.localWriteOptions = bedrock.config.mongodb.local.writeOptions;
 
-// load test config
-bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
+-// load test config
+-bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
 
 bedrock.events.on('bedrock.init', promisify(init));
 
@@ -708,7 +708,15 @@ function _connect(options, callback) {
       server: config.connectOptions
     };
   }
-
+  if(config.username && config.password) {
+    connectOptions.auth = {
+      user: config.username,
+      password: config.password
+    };
+    // authSource is the database to authentication against
+    // this is usually admin
+    connectOptions.authSource = connectOptions.authSource || 'admin';
+  }
   MongoClient.connect(options.url, connectOptions, (err, client) => {
     if(!err && !options.init) {
       logger.info('connecting to database: ' + options.url);

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,6 @@ function init(callback) {
         options: {unique: true, background: true}
       }], callback)],
     setupLocal: ['openLocal', (results, callback) => {
-console.log('setupLocal', results);
       // setup machine-local (non-replicated) database
       api.localClient = results.openLocal;
       if(!results.openLocal) {
@@ -650,7 +649,6 @@ function _openDatabase(options, callback) {
       }
       const db = results.connect.db;
       let authRequired = false;
-console.log('listDatabases called');
       db.admin().listDatabases(null, err => {
         // if an authorization error is returned, authorization is required
         if(err && err.code === 13) {
@@ -735,7 +733,6 @@ function _connect(options, callback) {
  * @returns {Promise} The result of the connect.
 */
 async function _loginUser({auth, opts, callback, server}) {
-console.log('_loginUser', {auth, opts, callback, server});
   const client = new MongoClient(server, {
     auth,
     ...opts

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -10,8 +10,6 @@ const config = require('bedrock').config;
 config.mongodb.name = 'bedrock_test';
 config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
-config.mongodb.username = 'bedrock';
-config.mongodb.password = 'password';
 config.mongodb.adminPrompt = true;
 
 config.mongodb.writeOptions = {

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -8,17 +8,17 @@ const path = require('path');
 
 // MongoDB
 config.mongodb.name = 'test-connectOptions';
-config.mongodb.host = process.env.mongo_host || 'localhost';
-config.mongodb.port = process.env.mongo_port || 27017;
-config.mongodb.connectOptions.replicaSet = process.env.mongo_replica;
-if(process.env.mongo_username && process.env.mongo_password) {
+config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
+config.mongodb.port = process.env.MONGODB_PORT || 27017;
+config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
+if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
   const {connectOptions} = config.mongodb;
   connectOptions.ssl = true;
   connectOptions.auth = {
-    user: process.env.mongo_username || 'admin',
-    password: process.env.mongo_password || 'admin'
+    user: process.env.MONGODB_USERNAME || 'admin',
+    password: process.env.MONGODB_PASSWORD || 'admin'
   };
-  connectOptions.authSource = process.env.mongo_authdb;
+  connectOptions.authSource = process.env.MONGODB_AUTHSOURCE || 'admin';
 }
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -12,22 +12,15 @@ config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
 config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
+  config.mongodb.username = process.env.MONGODB_USERNAME;
+  config.mongodb.password = process.env.MONGODB_PASSWORD;
   const {connectOptions} = config.mongodb;
   connectOptions.ssl = true;
-  connectOptions.auth = {
-    user: process.env.MONGODB_USERNAME || 'admin',
-    password: process.env.MONGODB_PASSWORD || 'admin'
-  };
   connectOptions.authSource = process.env.MONGODB_AUTHSOURCE || 'admin';
 }
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
-/**
-config.mongodb.authentication = {
-  authMechanism: 'SCRAM-SHA-1'
-};
-*/
 config.mongodb.forceAuthentication = true;
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,16 +7,18 @@ const {config} = require('bedrock');
 const path = require('path');
 
 // MongoDB
-config.mongodb.name = 'test-connectOptions';
+config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
-config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
   config.mongodb.username = process.env.MONGODB_USERNAME;
   config.mongodb.password = process.env.MONGODB_PASSWORD;
   const {connectOptions} = config.mongodb;
+  // this can be false
   connectOptions.ssl = true;
   connectOptions.authSource = process.env.MONGODB_AUTHSOURCE || 'admin';
+  // this can safely be undefined
+  config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 }
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,13 +7,16 @@ const {config} = require('bedrock');
 const path = require('path');
 
 // MongoDB
-config.mongodb.name = 'test';
+config.mongodb.name = 'test-connectOptions';
 config.mongodb.host = process.env.mongo_host;
 config.mongodb.port = process.env.mongo_port;
-config.mongodb.username = process.env.mongo_username;
-config.mongodb.password = process.env.mongo_password;
 config.mongodb.connectOptions.replicaSet = process.env.mongo_replica;
 config.mongodb.connectOptions.ssl = true;
+config.mongodb.connectOptions.auth = {
+  user: process.env.mongo_username,
+  password: process.env.mongo_password
+};
+config.mongodb.connectOptions.authSource = 'admin';
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -8,15 +8,18 @@ const path = require('path');
 
 // MongoDB
 config.mongodb.name = 'test-connectOptions';
-config.mongodb.host = process.env.mongo_host;
-config.mongodb.port = process.env.mongo_port;
+config.mongodb.host = process.env.mongo_host || 'localhost';
+config.mongodb.port = process.env.mongo_port || 27017;
 config.mongodb.connectOptions.replicaSet = process.env.mongo_replica;
-config.mongodb.connectOptions.ssl = true;
-config.mongodb.connectOptions.auth = {
-  user: process.env.mongo_username,
-  password: process.env.mongo_password
-};
-config.mongodb.connectOptions.authSource = 'admin';
+if(process.env.mongo_username && process.env.mongo_password) {
+  const {connectOptions} = config.mongodb;
+  connectOptions.ssl = true;
+  connectOptions.auth = {
+    user: process.env.mongo_username || 'admin',
+    password: process.env.mongo_password || 'admin'
+  };
+  connectOptions.authSource = process.env.mongo_authdb;
+}
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
@@ -28,4 +31,3 @@ config.mongodb.authentication = {
 config.mongodb.forceAuthentication = true;
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
-console.log('mongo config', config.mongodb);

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -8,6 +8,8 @@ const path = require('path');
 
 // MongoDB
 config.mongodb.name = 'bedrock_mongodb_test';
+config.mongodb.host = 'localhost';
+config.mongodb.port = 27017;
 config.mongodb.username = 'test';
 config.mongodb.password = 'test';
 config.mongodb.dropCollections.onInit = true;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,11 +7,14 @@ const {config} = require('bedrock');
 const path = require('path');
 
 // MongoDB
-config.mongodb.name = 'bedrock_mongodb_test';
-config.mongodb.host = 'localhost';
-config.mongodb.port = 27017;
-config.mongodb.username = 'test';
-config.mongodb.password = 'test';
+config.mongodb.name = 'test';
+config.mongodb.host = process.env.mongo_host;
+config.mongodb.port = process.env.mongo_port;
+config.mongodb.username = process.env.mongo_username;
+config.mongodb.password = process.env.mongo_password;
+config.mongodb.connectOptions.replicaSet = process.env.mongo_replica;
+config.mongodb.connectOptions.ssl = true;
+//config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 /**
@@ -22,3 +25,4 @@ config.mongodb.authentication = {
 config.mongodb.forceAuthentication = true;
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
+console.log('mongo config', config.mongodb);


### PR DESCRIPTION
Already found a bug. Because we are using callbacks if the connect fails then client is undefined. If client is undefined then `client.db` is also undefined. This results in getting an object undefined error instead of the connection error you would expect. So we check if `client` exists before calling on `client.db` then if there is no client we pass the connection error to the callback.