### PR TITLE
Do not rewrite URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # bedrock-mongodb ChangeLog
 
+## 8.0.0 -
+
+### Changed
+- **BREAKING**: Removed support for localCollections.
+- _createUser now works with mongoDB node driver 3.5.
+- Removed _addLocalUser (_createUser can now handle this).
+- Removed local config options from `config.js`.
+- Throw if the MongoDB serverVersion is less than 2.6.
+
+### Added
+- Prompt admin for `authSource` in the adminPrompt.
+
 ## 7.1.0 - 2020-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ connectOptions.tls = true;
 // it should be specified or else it will be the `mongodb.name`
 connectOptions.authSource = 'my_provider_auth_db'; 
 ```
+MongoDB provides [excellent docs on their connection strings](https://docs.mongodb.com/manual/reference/connection-string/)
+
+You can connect using a url by setting:
+```js
+config.mongodb.url = 'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin';
+```
 
 ## Requirements
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,8 @@ config.mongodb.connectOptions = {
   serverSelectionTimeoutMS: 30000,
   autoReconnect: false,
   useNewUrlParser: true,
+  // the db to authenticate against
+  authSource: undefined
 };
 config.mongodb.writeOptions = {
   j: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -70,5 +70,5 @@ config.mongodb.requirements = {};
 // server version requirement with server-style string
 config.mongodb.requirements.serverVersion = '>=4.2';
 
-// this is used by _createUser to add a user as an admin
-//config.mongodb.collection = 'admin-collection';
+// this is used by _createUser to add a user as an admin to a collection
+// config.mongodb.collection = 'admin-collection';

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,10 +14,6 @@ config.mongodb = {};
 // credentials, and any server options will be parsed from the URL and override
 // the broken-down configuration options set here.
 //
-// If `config.mongodb.local.url` is not set, the connection URL for the local
-// database will be assembled from `config.mongodb.local.name`,
-// `config.mongodb.host` and `config.mongodb.port`.
-//
 // At a minimum, the URL must specify a host, port, and database name. It may
 // omit a username and password if those are provided as
 // `config.mongodb.username` and `config.mongodb.password`, otherwise those
@@ -68,24 +64,9 @@ config.mongodb.options = {
   j: true
 };
 
-// local database config
-//
-// The local database is an optimization for nodes that are able to store
-// local state. It reduces the need to allocate global ids for each new
-// process. If replica sets are used for the main database, the local
-// database should be configured as a separate database instance on each
-// node.
-config.mongodb.local = {};
-config.mongodb.local.enable = false;
-// config.mongodb.local.url = 'mongodb://localhost:27017/local';
-config.mongodb.local.name = 'local';
-config.mongodb.local.collection = 'bedrock_dev';
-config.mongodb.local.writeOptions = {
-  w: 1,
-  j: true,
-  multi: true
-};
-
 config.mongodb.requirements = {};
 // server version requirement with server-style string
 config.mongodb.requirements.serverVersion = '>=4.2';
+
+// this is used by _createUser to add a user as an admin
+//config.mongodb.collection = 'admin-collection';

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,15 @@ function init(callback) {
   const config = bedrock.config.mongodb;
 
   if(!config.url) {
-    config.url = `mongodb://${config.host}:${config.port}/${config.name}`;
+    config.url = 'mongodb://';
+    if(config.username) {
+      config.url += `${config.username}:${config.password}@`;
+    }
+    config.url += `${config.host}:${config.port}/${config.name}`;
+    if(config.username) {
+      // TODO: formalize support for alternate authSource
+      config.url += '?authSource=admin';
+    }
   }
 
   // if(config.url) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,10 @@
 /*
  * Bedrock mongodb module.
  *
- * This modules exposes an API for accessing the shared and local databases.
+ * This modules exposes an API for accessing MongoDB databases.
  * This API is mostly used to communicate with the shared database -- this
  * database can be sharded and replicated across multiple machines. Any shared
  * collections are exposed via this module's 'collections' property.
- *
- * The API also exposes a single document in a local database. This database
- * is not sharded or replicated to other machines. It has a single collection
- * with a single document that can be updated atomically. The expectation is
- * that very little data needs to be stored locally (eg: local parts of
- * distributed IDs, etc.). This module exposes the local collection via
- * the 'localCollection' property. The single local document in that
- * collection has two properties: 'id' and 'local'. The value of 'id'
- * is exposed by this module as 'localDocumentId'. The value of 'local' is
- * a JSON object where local properties should be stored.
  *
  * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
@@ -58,7 +48,6 @@ let testMode = false;
 
 // database client(s)
 api.client = null;
-api.localClient = null;
 
 // database itself
 api.db = null;
@@ -66,14 +55,8 @@ api.db = null;
 // shared collections cache
 api.collections = {};
 
-// local collection
-api.localCollection = null;
-// local document ID
-api.localDocumentId = 'local';
-
 // default database write options
 api.writeOptions = bedrock.config.mongodb.writeOptions;
-api.localWriteOptions = bedrock.config.mongodb.local.writeOptions;
 
 // load test config
 bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
@@ -115,17 +98,6 @@ function init(callback) {
         init: false
       }, callback);
     }],
-    openLocal: ['initDatabase', (results, callback) => {
-      if(!config.local.enable) {
-        logger.debug('opening local database disabled');
-        return callback(null, null);
-      }
-      logger.info('opening local database', {url: config.local.url});
-      _openDatabase({
-        url: config.local.url,
-        init: false
-      }, callback);
-    }],
     dropCollections: ['open', (results, callback) => {
       api.client = results.open.client;
       api.db = results.open.db;
@@ -142,14 +114,6 @@ function init(callback) {
         fields: {namespace: 1},
         options: {unique: true, background: true}
       }], callback)],
-    setupLocal: ['openLocal', (results, callback) => {
-      // setup machine-local (non-replicated) database
-      api.localClient = results.openLocal;
-      if(!results.openLocal) {
-        return callback();
-      }
-      _setupLocalDatabase(callback);
-    }]
   }, err => {
     if(err) {
       logger.error('could not initialize database', err);
@@ -411,52 +375,6 @@ api.decode = value => {
 };
 
 /**
- * Connects to and prepares the machine-local (non-replicated) database.
- *
- * @param callback(err) called once the operation completes.
- */
-function _setupLocalDatabase(callback) {
-  // local collection name
-  const name = bedrock.config.mongodb.local.collection;
-
-  async.waterfall([
-    // create local collection
-    callback => api.localClient.createCollection(
-      name, function ignoreAlreadyExists(err) {
-        if(err) {
-          if(api.isAlreadyExistsError(err)) {
-            err = null;
-          }
-          return callback(err);
-        }
-        logger.debug('local collection created: ' + name);
-        callback();
-      }),
-    // open local collection
-    callback => api.localClient.collection(name, callback),
-    (collection, callback) => {
-      // cache local collection
-      api.localCollection = collection;
-
-      // create index
-      api.localCollection.createIndex(
-        {id: true}, {unique: true, background: true}, err => callback(err));
-    },
-    callback => {
-      // insert local document
-      const record = {id: api.localDocumentId, local: {}};
-      api.localCollection.insertOne(record, api.localWriteOptions, err => {
-        // ignore duplicate errors
-        if(err && api.isDuplicateError(err)) {
-          err = null;
-        }
-        callback(err);
-      });
-    }
-  ], callback);
-}
-
-/**
  * Returns true if the given error is a MongoDB 'already exists' error.
  *
  * @param err the error to check.
@@ -497,7 +415,7 @@ api.getNextUpdateId = updateId => (updateId < 0xffffffff) ? (updateId + 1) : 0;
 function _initDatabase(callback) {
   const config = bedrock.config.mongodb;
 
-  // connect to shared and local dbs
+  // connect to dbs
   let client;
   let db;
   async.auto({
@@ -529,39 +447,12 @@ function _initDatabase(callback) {
           }, err));
       });
     },
-    openLocal: callback => {
-      if(!config.local.enable) {
-        logger.debug('initializing local database disabled');
-        return callback(null, null);
-      }
-      logger.info('initializing local database', {url: config.local.url});
-      _openDatabase({url: config.local.url, init: true}, (err, results) => {
-        db = results.db;
-        if(!err) {
-          return callback(null, true);
-        }
-        if(api.isDatabaseError(err) && (err.code === MDBE_AUTH_FAILED ||
-          err.message === 'could not authenticate')) {
-          // auth failed, either DB didn't exist or bad credentials
-          logger.info('local database authentication failed:' +
-            ' db=' + config.local.name +
-            ' username=' + config.username);
-          if(config.adminPrompt) {
-            return callback(null, false);
-          }
-        }
-        return callback(new BedrockError(
-          'Could not initialize local database.',
-          'DatabaseError', {
-            url: config.local.url
-          }, err));
-      });
-    },
-    check: ['open', 'openLocal', (results, callback) => {
+    check: ['open', (results, callback) => {
       // open and authenticated, finish
-      if(results.open && (results.openLocal || !config.local.enable)) {
+      if(results.open) {
         return callback();
       }
+      // FIXME this might be deprecated
       // try to create user
       _createUser(client, db, callback);
     }]
@@ -573,12 +464,6 @@ function _initDatabase(callback) {
           return callback();
         }
         client.close(true, () => callback());
-      },
-      closeLocal: callback => {
-        if(!db) {
-          return callback();
-        }
-        db.close(true, () => callback());
       }
     }, () => callback(err));
   });
@@ -744,39 +629,6 @@ function _createUser(client, db, callback) {
     }],
     serverInfo: ['auth', (results, callback) =>
       db.admin().serverInfo(null, callback)],
-    addLocalUser: ['serverInfo', (results, callback) => {
-      if(!config.mongodb.local.enable) {
-        return callback();
-      }
-      // skip if user roles are used as they will provide access to local db
-      if(_usesRoles(results.serverInfo)) {
-        return callback();
-      }
-      async.auto({
-        // authenticate w/server as admin
-        auth: callback => _loginUser({
-          server,
-          opts,
-          callback,
-          auth: {
-            user: results.admin.username,
-            password: results.admin.password,
-            authdb: 'admin'
-          }
-        }),
-        removeUser: ['auth', (results, callback) => db.removeUser(
-          config.mongodb.username, err => {
-            // ignore user not found
-            if(api.isDatabaseError(err) && err.code === MDBE_USER_NOT_FOUND) {
-              err = null;
-            }
-            callback(err);
-          })],
-        addUser: ['removeUser', (results, callback) => _addLocalUser(
-          db, config.mongodb.username, config.mongodb.password,
-          config.mongodb.writeOptions, callback)]
-      }, callback);
-    }],
     // TODO: refactor to avoid removing user; driver doesn't seem to provide
     // high-level calls for granting roles, etc.
     removeUser: ['auth', (results, callback) => db.removeUser(
@@ -816,12 +668,12 @@ function _getAdminCredentials(callback) {
 }
 
 function _getAddUserOptions() {
-  const local = bedrock.config.mongodb.local;
+  const config = bedrock.config.mongodb;
   return bedrock.util.extend({}, bedrock.config.mongodb.writeOptions, {
     roles: [
       'dbOwner',
-      {role: 'dbAdmin', db: local.name, collection: local.collection},
-      {role: 'readWrite', db: local.name, collection: local.collection}
+      {role: 'dbAdmin', db: config.name, collection: config.collection},
+      {role: 'readWrite', db: config.name, collection: config.collection}
     ]
   });
 }
@@ -831,53 +683,6 @@ function _usesRoles(serverInfo) {
   return (
     (serverInfo.versionArray[0] == 2 && serverInfo.versionArray[1] >= 6) ||
     (serverInfo.versionArray[0] > 2));
-}
-
-function _addLocalUser(db, username, password, writeOptions, callback) {
-  db.addUser(username, password, writeOptions, err => {
-    // Note: Code below is from node-native-mongodb but instead always does
-    // user insert rather than an upsert; this behavior follows MongoDB >= 2.4
-    // and avoids a duplicate key error when writing a local user that
-    // occurs because a null _id key is used when upserting (vs. inserting)
-    if(err && api.isDuplicateError(err)) {
-      // clear duplicate error and try insert below
-      err = null;
-    }
-
-    // Use node md5 generator
-    const md5 = crypto.createHash('md5');
-    // Generate keys used for authentication
-    md5.update(username + ':mongo:' + password);
-    const userPassword = md5.digest('hex');
-    // Fetch a user collection
-    const collection = db.collection('system.users');
-    // Check if we are inserting the first user
-    collection.count({}, err => {
-      // We got an error (f.ex not authorized)
-      if(err) {
-        return callback(err, null);
-      }
-      // Check if the user already exists w/same password
-      collection.findOne({user: username, pwd: userPassword}, (err, result) => {
-        // We got an error (f.ex not authorized)
-        if(err) {
-          return callback(err, null);
-        }
-        // user already exists, continue
-        if(result) {
-          return callback(null, [{user: username, pwd: userPassword}]);
-        }
-        // insert new user
-        collection.insertOne(
-          {user: username, pwd: userPassword}, writeOptions, err => {
-            if(err) {
-              return callback(err, null);
-            }
-            callback(null, [{user: username, pwd: userPassword}]);
-          });
-      });
-    });
-  });
 }
 
 function _dropCollections(callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -601,7 +601,7 @@ function _connect(options, callback) {
  *
  * @param {object} options - Options to use.
  * @param {object} options.auth - user and password credentials.
- * @param {string} options.auth.user - The MongoDB usename.
+ * @param {string} options.auth.user - The MongoDB username.
  * @param {string} options.auth.password - The MongoDB password.
  * @param {object} options.opts - Options for the MongoClient.
  * @param {Server} options.url - A mongo connection string.

--- a/lib/index.js
+++ b/lib/index.js
@@ -533,7 +533,7 @@ function _openDatabase(options, callback) {
       // authSource should be set in connectOptions
       let opts = {...config.authentication, ...config.connectOptions};
       let url = config.url;
-      // if the user specified a connection string use it
+      // if the user specified a connection URL use it
       if(!url) {
         url = _createUrl(config);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,10 @@ bedrock.events.on('bedrock-cli.ready', () => {
 function init(callback) {
   const config = bedrock.config.mongodb;
 
+  if(!config.url) {
+    config.url = `mongodb://${config.host}:${config.port}/'${config.name}`;
+  }
+
   // if(config.url) {
   //   // update broken-down config values from URL
   //   const parsed = mongodbUri.parse(config.url);

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,19 +73,25 @@ bedrock.events.on('bedrock-cli.ready', () => {
   }
 });
 
+function _createUrl(config) {
+  let url = 'mongodb://';
+  if(config.username) {
+    url += `${config.username}:${config.password}@`;
+  }
+  url += `${config.host}:${config.port}/${config.name}`;
+  // this needs to come last
+  if(config.username) {
+    url +=
+      `?authSource=${config.connectOptions.authSource || 'admin'}`;
+  }
+  return url;
+}
+
 function init(callback) {
   const config = bedrock.config.mongodb;
 
   if(!config.url) {
-    config.url = 'mongodb://';
-    if(config.username) {
-      config.url += `${config.username}:${config.password}@`;
-    }
-    config.url += `${config.host}:${config.port}/${config.name}`;
-    if(config.username) {
-      // TODO: formalize support for alternate authSource
-      config.url += '?authSource=admin';
-    }
+    config.url = _createUrl(config);
   }
 
   async.auto({
@@ -452,9 +458,8 @@ function _initDatabase(callback) {
       if(results.open) {
         return callback();
       }
-      // FIXME this might be deprecated
       // try to create user
-      _createUser(client, db, callback);
+      _createUser(callback);
     }]
   }, err => {
     // force clients to close (do not reuse connections)
@@ -526,7 +531,6 @@ function _openDatabase(options, callback) {
       let opts = {...config.authentication, ...config.connectOptions};
       const server = new Server(config.host, config.port, opts);
       if(_usesRoles(results.serverInfo)) {
-        auth.authdb = config.name;
         // authenticate against shared db
         opts.authSource = config.connectOptions.authSource || config.name;
         return _loginUser({server, opts, auth, callback});
@@ -592,27 +596,28 @@ function _connect(options, callback) {
  * @param {object} options - Options to use.
  * @param {object} options.auth - user and password credentials.
  * @param {object} options.opts - Options for the MongoClient.
- * @param {Function} options.callback - A callback function.
  * @param {Server} options.server - The mongo server to connect to.
+ * @param {Function} options.callback - A callback function.
  *
  * @returns {Promise} The result of the connect.
 */
-async function _loginUser({auth, opts, callback, server}) {
-  const client = new MongoClient(server, {
-    auth,
-    ...opts
-  });
-  return client.connect(callback);
+async function _loginUser({auth, opts, server, callback}) {
+  return MongoClient.connect(server, {auth, ...opts}, callback);
 }
 
-function _createUser(client, db, callback) {
-  const config = bedrock.config;
-  const server = new Server(config.host, config.port);
+function _createUser(callback) {
+  const config = bedrock.config.mongodb;
   const opts = {...config.authentication, ...config.connectOptions};
-
+  const admin = {
+    db: null,
+    client: null,
+    auth: null,
+    session: null,
+    url: null
+  };
   console.log('\nA new, upgrade, or incomplete database setup scenario ' +
-    'has been detected. To ensure the database "' + config.mongodb.name +
-    '" exists and its primary user "' + config.mongodb.username + '" ' +
+    'has been detected. To ensure the database "' + config.name +
+    '" exists and its primary user "' + config.username + '" ' +
     'exists and has sufficient access privileges, please enter the ' +
     'following information.');
 
@@ -620,27 +625,34 @@ function _createUser(client, db, callback) {
     admin: _getAdminCredentials,
     // authenticate w/server as admin
     auth: ['admin', (results, callback) => {
-      const auth = {
+      admin.auth = {
         user: results.admin.username,
         password: results.admin.password,
-        authdb: 'admin'
+        authSource: results.admin.authSource || 'admin'
       };
-      _loginUser({auth, opts, callback, server});
+      opts.authSource = admin.auth.authSource;
+      const adminConfig = {...config, ...results.admin};
+      admin.url = _createUrl(adminConfig);
+      _loginUser({auth: admin.auth, opts, callback, server: admin.url});
     }],
-    serverInfo: ['auth', (results, callback) =>
-      db.admin().serverInfo(null, callback)],
+    serverInfo: ['auth', (results, callback) => {
+      admin.client = results.auth;
+      admin.session = admin.client.startSession();
+      admin.db = admin.client.db(admin.auth.authSource);
+      admin.db.admin().serverInfo(null, callback);
+    }],
     // TODO: refactor to avoid removing user; driver doesn't seem to provide
     // high-level calls for granting roles, etc.
-    removeUser: ['auth', (results, callback) => db.removeUser(
-      config.mongodb.username, err => {
+    removeUser: ['auth', (results, callback) => admin.db.removeUser(
+      config.username, {session: admin.session}, err => {
         // ignore user not found
         if(api.isDatabaseError(err) && err.code === MDBE_USER_NOT_FOUND) {
           err = null;
         }
         callback(err);
       })],
-    addUser: ['removeUser', (results, callback) => db.addUser(
-      config.mongodb.username, config.mongodb.password, _getAddUserOptions(),
+    addUser: ['removeUser', (results, callback) => admin.db.addUser(
+      config.username, config.password, _getAddUserOptions(),
       callback)]
   }, callback);
 }
@@ -662,6 +674,12 @@ function _getAdminCredentials(callback) {
           message: 'The password must be at least 8 characters.',
           hidden: true,
           default: 'password'
+        },
+        authSource: {
+          description: 'Enter the MongoDB administrator database',
+          pattern: /^.{4,}$/,
+          message: 'The authSource must be at least 4 characters.',
+          default: 'admin'
         }
       }
     }, callback);
@@ -669,7 +687,7 @@ function _getAdminCredentials(callback) {
 
 function _getAddUserOptions() {
   const config = bedrock.config.mongodb;
-  return bedrock.util.extend({}, bedrock.config.mongodb.writeOptions, {
+  return bedrock.util.extend({}, config.writeOptions, {
     roles: [
       'dbOwner',
       {role: 'dbAdmin', db: config.name, collection: config.collection},

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ function init(callback) {
   const config = bedrock.config.mongodb;
 
   if(!config.url) {
-    config.url = `mongodb://${config.host}:${config.port}/'${config.name}`;
+    config.url = `mongodb://${config.host}:${config.port}/${config.name}`;
   }
 
   // if(config.url) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const mongo = require('mongodb');
 const semver = require('semver');
 const {callbackify, promisify} = require('util');
 const {BedrockError} = bedrock.util;
-const {MongoClient, Server} = mongo;
+const {MongoClient} = mongo;
 
 // load config defaults
 require('./config');
@@ -522,15 +522,19 @@ function _openDatabase(options, callback) {
       if(!results.checkAuthRequired) {
         return callback(null, 'NotRequired');
       }
-      // construct an auth object for the MongoClient
-      const auth = {
-        user: config.username,
-        password: config.password
-      };
+      let auth = null;
+      // if there is a username & password set create an auth object for Mongo
+      if(config.username && config.password) {
+        auth = {
+          user: config.username,
+          password: config.password
+        };
+      }
+      // authSource should be set in connectOptions
       let opts = {...config.authentication, ...config.connectOptions};
       let url = config.url;
       // if the user specified a connection string use it
-      if(!config.url) {
+      if(!url) {
         url = _createUrl(config);
       }
       if(_usesRoles(results.serverInfo)) {
@@ -634,6 +638,10 @@ function _createUser(callback) {
         authSource: results.admin.authSource || 'admin'
       };
       opts.authSource = admin.auth.authSource;
+      // in case you forget to enter an authSource in the config.
+      if(!config.connectOptions.authSource) {
+        config.connectOptions.authSource = admin.auth.authSource;
+      }
       const adminConfig = {...config, ...results.admin};
       admin.url = _createUrl(adminConfig);
       _loginUser({auth: admin.auth, opts, url: admin.url, callback});

--- a/lib/index.js
+++ b/lib/index.js
@@ -607,9 +607,9 @@ function _connect(options, callback) {
  * @param {Server} options.url - A mongo connection string.
  * @param {Function} options.callback - A callback function.
  *
- * @returns {Promise} The result of the connect.
+ * @returns The result of the connect in the callback.
 */
-async function _loginUser({auth, opts, url, callback}) {
+function _loginUser({auth, opts, url, callback}) {
   return MongoClient.connect(url, {auth, ...opts}, callback);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,45 +94,45 @@ bedrock.events.on('bedrock-cli.ready', () => {
 function init(callback) {
   const config = bedrock.config.mongodb;
 
-  if(config.url) {
-    // update broken-down config values from URL
-    const parsed = mongodbUri.parse(config.url);
-    if('database' in parsed) {
-      config.name = parsed.database;
-    } else {
-      // ensure database is set
-      parsed.database = config.name;
-    }
-    if(parsed.hosts.length > 0) {
-      config.host = parsed.hosts[0].host;
-      if('port' in parsed.hosts[0]) {
-        config.port = parsed.hosts[0].port;
-      } else {
-        // default mongodb port
-        config.port = 27017;
-      }
-    }
-    if('username' in parsed) {
-      config.username = parsed.username;
-      delete parsed.username;
-    }
-    if('password' in parsed) {
-      config.password = parsed.password;
-      delete parsed.password;
-    }
-    // rewrite URL w/o auth credentials
-    config.url = mongodbUri.format(parsed);
-  } else {
-    // build URL
-    config.url =
-      'mongodb://' + config.host + ':' + config.port + '/' + config.name;
-  }
+  // if(config.url) {
+  //   // update broken-down config values from URL
+  //   const parsed = mongodbUri.parse(config.url);
+  //   if('database' in parsed) {
+  //     config.name = parsed.database;
+  //   } else {
+  //     // ensure database is set
+  //     parsed.database = config.name;
+  //   }
+  //   if(parsed.hosts.length > 0) {
+  //     config.host = parsed.hosts[0].host;
+  //     if('port' in parsed.hosts[0]) {
+  //       config.port = parsed.hosts[0].port;
+  //     } else {
+  //       // default mongodb port
+  //       config.port = 27017;
+  //     }
+  //   }
+  //   if('username' in parsed) {
+  //     config.username = parsed.username;
+  //     delete parsed.username;
+  //   }
+  //   if('password' in parsed) {
+  //     config.password = parsed.password;
+  //     delete parsed.password;
+  //   }
+  //   // rewrite URL w/o auth credentials
+  //   config.url = mongodbUri.format(parsed);
+  // } else {
+  //   // build URL
+  //   config.url =
+  //     'mongodb://' + config.host + ':' + config.port + '/' + config.name;
+  // }
 
-  if(!config.local.url) {
-    // build local URL
-    config.local.url =
-      'mongodb://' + config.host + ':' + config.port + '/' + config.local.name;
-  }
+  // if(!config.local.url) {
+  //   // build local URL
+  //   config.local.url =
+  //     'mongodb://' + config.host + ':' + config.port + '/' + config.local.name;
+  // }
 
   async.auto({
     initDatabase: callback => callbackify(bedrock.runOnce)(

--- a/lib/index.js
+++ b/lib/index.js
@@ -531,7 +531,7 @@ function _openDatabase(options, callback) {
         };
       }
       // authSource should be set in connectOptions
-      let opts = {...config.authentication, ...config.connectOptions};
+      const opts = {...config.authentication, ...config.connectOptions};
       let url = config.url;
       // if the user specified a connection URL use it
       if(!url) {
@@ -541,11 +541,10 @@ function _openDatabase(options, callback) {
         // authenticate against shared db
         return _loginUser({url, opts, auth, callback});
       }
-      // FIXME this code will never be called because serverVersion is 4.2
-      // backwards-compatible mode; auth using opened db
-      const {authSource = config.name} = config.connectOptions || {};
-      opts = {...opts, authSource};
-      _loginUser({url, opts, auth, callback});
+      const version = results.serverInfo.versionArray.join('.');
+      throw new BedrockError(
+        `MongoDB server version ${version} is unsupported.`,
+        'NotSupportedError');
     }],
     authSuccess: ['auth', (results, callback) => {
       if(results.auth === 'NotRequired') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,6 @@ const bedrock = require('bedrock');
 const crypto = require('crypto');
 const logger = require('./logger');
 const mongo = require('mongodb');
-const mongodbUri = require('mongodb-uri');
 const semver = require('semver');
 const {callbackify, promisify} = require('util');
 const {BedrockError} = bedrock.util;
@@ -105,46 +104,6 @@ function init(callback) {
       config.url += '?authSource=admin';
     }
   }
-
-  // if(config.url) {
-  //   // update broken-down config values from URL
-  //   const parsed = mongodbUri.parse(config.url);
-  //   if('database' in parsed) {
-  //     config.name = parsed.database;
-  //   } else {
-  //     // ensure database is set
-  //     parsed.database = config.name;
-  //   }
-  //   if(parsed.hosts.length > 0) {
-  //     config.host = parsed.hosts[0].host;
-  //     if('port' in parsed.hosts[0]) {
-  //       config.port = parsed.hosts[0].port;
-  //     } else {
-  //       // default mongodb port
-  //       config.port = 27017;
-  //     }
-  //   }
-  //   if('username' in parsed) {
-  //     config.username = parsed.username;
-  //     delete parsed.username;
-  //   }
-  //   if('password' in parsed) {
-  //     config.password = parsed.password;
-  //     delete parsed.password;
-  //   }
-  //   // rewrite URL w/o auth credentials
-  //   config.url = mongodbUri.format(parsed);
-  // } else {
-  //   // build URL
-  //   config.url =
-  //     'mongodb://' + config.host + ':' + config.port + '/' + config.name;
-  // }
-
-  // if(!config.local.url) {
-  //   // build local URL
-  //   config.local.url =
-  //     'mongodb://' + config.host + ':' + config.port + '/' + config.local.name;
-  // }
 
   async.auto({
     initDatabase: callback => callbackify(bedrock.runOnce)(

--- a/lib/index.js
+++ b/lib/index.js
@@ -423,7 +423,6 @@ function _initDatabase(callback) {
 
   // connect to dbs
   let client;
-  let db;
   async.auto({
     open: callback => {
       // TODO: merge similar callbacks below into single function
@@ -529,17 +528,20 @@ function _openDatabase(options, callback) {
         password: config.password
       };
       let opts = {...config.authentication, ...config.connectOptions};
-      const server = new Server(config.host, config.port, opts);
+      let url = config.url;
+      // if the user specified a connection string use it
+      if(!config.url) {
+        url = _createUrl(config);
+      }
       if(_usesRoles(results.serverInfo)) {
         // authenticate against shared db
-        opts.authSource = config.connectOptions.authSource || config.name;
-        return _loginUser({server, opts, auth, callback});
+        return _loginUser({url, opts, auth, callback});
       }
       // FIXME this code will never be called because serverVersion is 4.2
       // backwards-compatible mode; auth using opened db
-      opts = {...opts, authSource: db.databaseName};
-      auth.authdb = db.databaseName;
-      _loginUser({server, opts, auth, callback});
+      const {authSource = config.name} = config.connectOptions || {};
+      opts = {...opts, authSource};
+      _loginUser({url, opts, auth, callback});
     }],
     authSuccess: ['auth', (results, callback) => {
       if(results.auth === 'NotRequired') {
@@ -595,14 +597,16 @@ function _connect(options, callback) {
  *
  * @param {object} options - Options to use.
  * @param {object} options.auth - user and password credentials.
+ * @param {string} options.auth.user - The MongoDB usename.
+ * @param {string} options.auth.password - The MongoDB password.
  * @param {object} options.opts - Options for the MongoClient.
- * @param {Server} options.server - The mongo server to connect to.
+ * @param {Server} options.url - A mongo connection string.
  * @param {Function} options.callback - A callback function.
  *
  * @returns {Promise} The result of the connect.
 */
-async function _loginUser({auth, opts, server, callback}) {
-  return MongoClient.connect(server, {auth, ...opts}, callback);
+async function _loginUser({auth, opts, url, callback}) {
+  return MongoClient.connect(url, {auth, ...opts}, callback);
 }
 
 function _createUser(callback) {
@@ -612,7 +616,6 @@ function _createUser(callback) {
     db: null,
     client: null,
     auth: null,
-    session: null,
     url: null
   };
   console.log('\nA new, upgrade, or incomplete database setup scenario ' +
@@ -633,18 +636,17 @@ function _createUser(callback) {
       opts.authSource = admin.auth.authSource;
       const adminConfig = {...config, ...results.admin};
       admin.url = _createUrl(adminConfig);
-      _loginUser({auth: admin.auth, opts, callback, server: admin.url});
+      _loginUser({auth: admin.auth, opts, url: admin.url, callback});
     }],
     serverInfo: ['auth', (results, callback) => {
       admin.client = results.auth;
-      admin.session = admin.client.startSession();
       admin.db = admin.client.db(admin.auth.authSource);
       admin.db.admin().serverInfo(null, callback);
     }],
     // TODO: refactor to avoid removing user; driver doesn't seem to provide
     // high-level calls for granting roles, etc.
     removeUser: ['auth', (results, callback) => admin.db.removeUser(
-      config.username, {session: admin.session}, err => {
+      config.username, err => {
         // ignore user not found
         if(api.isDatabaseError(err) && err.code === MDBE_USER_NOT_FOUND) {
           err = null;

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -19,14 +19,6 @@ config.mongodb.writeOptions = {
   multi: true
 };
 
-config.mongodb.local.name = 'local';
-config.mongodb.local.collection = 'bedrock_test';
-config.mongodb.local.writeOptions = {
-  safe: true,
-  j: true,
-  multi: true
-};
-
 // these settings are only effective if `test` is specified on the command line
 // when onInit = true, collections are dropped on initialization
 config.mongodb.dropCollections = {};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "async": "^2.6.3",
     "lodash": "^4.17.15",
     "mongodb": "^3.5.7",
-    "mongodb-uri": "^0.9.7",
     "progress": "~1.1.8",
     "prompt": "~0.2.14",
     "semver": "^6.3.0"

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^7.4.0",
-    "eslint-config-digitalbazaar": "^2.5.0"
+    "eslint": "^7.9.0",
+    "eslint-config-digitalbazaar": "^2.6.1"
   },
   "engines": {
     "node": ">=8"

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -10,6 +10,7 @@ const path = require('path');
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
+
 if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
   config.mongodb.username = process.env.MONGODB_USERNAME;
   config.mongodb.password = process.env.MONGODB_PASSWORD;


### PR DESCRIPTION
Creating this so that someone can spend some time figuring out what is needed out of this URL rewriting business that is being commented out here.

When connecting with Mongodb Atlas, the url must begin with `mongodb+srv` as shown here: https://docs.mongodb.com/drivers/node

The commented code appears to be dropping that and replacing it with just `mongodb` which does not work with sharded clusters.  Maybe preserving the protocol portion of the URL will just work.