### PR TITLE
Remove deprecated collection name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -724,13 +724,13 @@ function _dropCollections(callback) {
   const cArray = bedrock.config.mongodb.dropCollections.collections;
   api.db.collections((skip, collections) => {
     async.each(collections, (collection, callback) => {
-      if(collection.s.name === 'system.indexes') {
+      if(collection.collectionName === 'system.indexes') {
         return callback();
       }
-      if(cArray.length > 0 && cArray.indexOf(collection.s.name) == -1) {
+      if(cArray.length > 0 && cArray.indexOf(collection.collectionName) == -1) {
         return callback();
       }
-      logger.debug(`dropping collection: ${collection.s.namespace}`);
+      logger.debug(`dropping collection: ${collection.namespace}`);
       collection.drop(err => {
         if(err && err.message === 'ns not found') {
           // ignore collection not found error

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
+    "debug": "node --preserve-symlinks test.js test --log-level debug",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=text-lcov npm test > coverage.lcov",
     "coverage-report": "nyc report"


### PR DESCRIPTION
I'm really sorry about this one: I left two deprecated instances in a function used by the majority of our test projects:

`collection.s.name` is now `collection.collectionName`: http://mongodb.github.io/node-mongodb-native/3.5/api/Collection.html#namespace

Addresses:
https://github.com/digitalbazaar/bedrock-mongodb/issues/55