### PR TITLE
Use database sepecified in the connect string when calling `client.db()`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -583,15 +583,19 @@ function _connect(options, callback) {
     // this is usually `admin` in dev and a specific db in production
     connectOptions.authSource = config.connectOptions.authSource || config.name;
   }
+
   MongoClient.connect(options.url, connectOptions, (err, client) => {
-    if(!err && !options.init) {
+    if(err) {
+      return callback(err);
+    }
+
+    if(!options.init) {
       logger.info('connecting to database: ' + options.url);
     }
-    let db = null;
-    if(client) {
-      db = client.db(config.name);
-    }
-    callback(err, {db, client});
+
+    const db = client.db();
+
+    callback(null, {db, client});
   });
 }
 


### PR DESCRIPTION
This in service of specifying ONLY the `url` when connecting.  The operative bit here is the removal of `config.name` from the `client.db()` call that was on L592, and is now on L596. The unexpected behavior caused by this has been haunting me for a while.  The unexpected behavior occurs when one is specifying a self contained url string that is designed to provide the database, username and password, whereby none of these values are set to non-default values in the config.  

For instance: `mongodb://my-user:my-password@mongos.example.com:27075/my_database?ssl=true`.  With this connect string solely, a valid authenticated database connection can be made.  However, with line `client.db(config.name)`, the client tries to connect to a non-existent database, `bedrock_dev` (the default value) and an authentication error ensues because the user that has authenticated to the database `my_database` has no permissions for the `bedrock_dev` database.

`client.db()` when called with no options, returns the database that was from the connect string, and therefore it is redundant at best, and creates a problem if `config.name` is not being set because the `url` config is in effect.

See: https://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html#db