### PR TITLE
Return early if there are no unopened collections.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,11 @@ api.openCollections = brCallbackify(async names => {
     }
   }
 
+  // return early if there are no unopened collections
+  if(unopened.length === 0) {
+    return;
+  }
+
   // create collections as necessary (ignore already exists error)
   await Promise.all(unopened.map(async name => {
     logger.debug('creating collection: ' + name);


### PR DESCRIPTION
Fixes a bug caused by attempting to open collections an empty set of collections. This resulted in excessive and redundant logging.

Regression can be found here:
https://github.com/digitalbazaar/bedrock-mongodb/commit/52d32fa3883373cc73a7acaf5706230c58b566cf#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1L130-L183

