### PR TITLE
Use write concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-mongodb ChangeLog
 
+## 8.2.0 -
+
+### Removed
+- `options.mongodb`
+- Calls on `w`, `j`, `wtimeout`, and `fsync`.
+
+### Added
+- Support for mongodb's new `writeConcern` option.
+
 ## 8.1.1 - 2020-12-15
 
 ### Fixed

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,8 +41,10 @@ config.mongodb.authentication = {
   // authMechanism: 'MONGODB-CR'
 };
 config.mongodb.connectOptions = {
-  w: 'majority',
-  j: true,
+  writeConcern: {
+    w: 'majority',
+    j: true
+  },
   useUnifiedTopology: true,
   serverSelectionTimeoutMS: 30000,
   autoReconnect: false,
@@ -53,8 +55,10 @@ config.mongodb.connectOptions = {
   promoteBuffers: true,
 };
 config.mongodb.writeOptions = {
-  j: true,
-  w: 'majority',
+  writeConcern: {
+    j: true,
+    w: 'majority'
+  },
   // as mongo 4.2 this is no longer used by updateOne or updateMany
   // FIXME remove this once all dependencies have been upgraded
   multi: true,
@@ -63,9 +67,11 @@ config.mongodb.writeOptions = {
 };
 /* DEPRECATED */
 config.mongodb.options = {
-  w: 'majority',
-  journal: true,
-  j: true
+  writeConcern: {
+    w: 'majority',
+    j: true
+  },
+  journal: true
 };
 
 config.mongodb.requirements = {};

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,9 +59,6 @@ config.mongodb.writeOptions = {
     j: true,
     w: 'majority'
   },
-  // as mongo 4.2 this is no longer used by updateOne or updateMany
-  // FIXME remove this once all dependencies have been upgraded
-  multi: true,
   // this is used by insert methods
   forceServerObjectId: true,
 };
@@ -70,8 +67,7 @@ config.mongodb.options = {
   writeConcern: {
     w: 'majority',
     j: true
-  },
-  journal: true
+  }
 };
 
 config.mongodb.requirements = {};

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,7 +43,7 @@ config.mongodb.authentication = {
 
 const writeConcern = config.mongodb.writeConcern = {
   w: 'majority',
-  j: true
+  j: true,
 };
 
 config.mongodb.connectOptions = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,14 +41,8 @@ config.mongodb.authentication = {
   // authMechanism: 'MONGODB-CR'
 };
 
-const writeConcern = config.mongodb.writeConcern = {
-  w: 'majority',
-  j: true,
-};
-
 // this is used when making an initial connection
 config.mongodb.connectOptions = {
-  writeConcern,
   useUnifiedTopology: true,
   serverSelectionTimeoutMS: 30000,
   autoReconnect: false,
@@ -61,7 +55,10 @@ config.mongodb.connectOptions = {
 
 // this is used by insert methods
 config.mongodb.writeOptions = {
-  writeConcern,
+  writeConcern: {
+    w: 'majority',
+    j: true,
+  },
   forceServerObjectId: true,
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,10 +62,6 @@ config.mongodb.writeOptions = {
   // this is used by insert methods
   forceServerObjectId: true,
 };
-/* DEPRECATED */
-config.mongodb.options = {
-  writeConcern
-};
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,7 +41,7 @@ config.mongodb.authentication = {
   // authMechanism: 'MONGODB-CR'
 };
 
-// this is used when making an initial connection
+// this is used when making connections to the database
 config.mongodb.connectOptions = {
   useUnifiedTopology: true,
   serverSelectionTimeoutMS: 30000,

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,6 +46,7 @@ const writeConcern = config.mongodb.writeConcern = {
   j: true,
 };
 
+// this is used when making an initial connection
 config.mongodb.connectOptions = {
   writeConcern,
   useUnifiedTopology: true,
@@ -57,9 +58,10 @@ config.mongodb.connectOptions = {
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
 };
+
+// this is used by insert methods
 config.mongodb.writeOptions = {
   writeConcern,
-  // this is used by insert methods
   forceServerObjectId: true,
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,11 +40,14 @@ config.mongodb.authentication = {
   // used by MongoDB < 3.0
   // authMechanism: 'MONGODB-CR'
 };
+
+const writeConcern = config.mongodb.writeConcern = {
+  w: 'majority',
+  j: true
+};
+
 config.mongodb.connectOptions = {
-  writeConcern: {
-    w: 'majority',
-    j: true
-  },
+  writeConcern,
   useUnifiedTopology: true,
   serverSelectionTimeoutMS: 30000,
   autoReconnect: false,
@@ -55,19 +58,13 @@ config.mongodb.connectOptions = {
   promoteBuffers: true,
 };
 config.mongodb.writeOptions = {
-  writeConcern: {
-    j: true,
-    w: 'majority'
-  },
+  writeConcern,
   // this is used by insert methods
   forceServerObjectId: true,
 };
 /* DEPRECATED */
 config.mongodb.options = {
-  writeConcern: {
-    w: 'majority',
-    j: true
-  }
+  writeConcern
 };
 
 config.mongodb.requirements = {};

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,7 @@ config.mongodb.connectOptions = {
   promoteBuffers: true,
 };
 
-// this is used by insert methods
+// this is used when writing to the database
 config.mongodb.writeOptions = {
   writeConcern: {
     w: 'majority',

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,6 +131,7 @@ function init(callback) {
 api.openCollections = brCallbackify(async names => {
   // remove collections that are already open
   const unopened = [];
+  const {writeConcern} = bedrock.config.mongodb;
   for(const name of names) {
     if(!(name in api.collections)) {
       unopened.push(name);
@@ -146,7 +147,7 @@ api.openCollections = brCallbackify(async names => {
   await Promise.all(unopened.map(async name => {
     logger.debug('creating collection: ' + name);
     try {
-      await api.db.createCollection(name);
+      await api.db.createCollection(name, {writeConcern});
     } catch(e) {
       if(!api.isAlreadyExistsError(e)) {
         throw e;
@@ -159,7 +160,7 @@ api.openCollections = brCallbackify(async names => {
   logger.debug('opening collections', {collections: unopened});
   const collections = {};
   await Promise.all(unopened.map(async name => {
-    collections[name] = await api.db.collection(name);
+    collections[name] = await api.db.collection(name, {writeConcern});
   }));
 
   // merge results into collection cache

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,7 @@ api.createIndexes = brCallbackify(async options => {
  * @return the new GridFSBucket instance
  */
 api.createGridFSBucket = options => {
-  const opts = {...options, ...api.writeOptions};
+  const opts = {...bedrock.config.mongodb.writeOptions, ...options};
   return new mongo.GridFSBucket(api.db, opts);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -554,7 +554,6 @@ function _connect(options, callback) {
   }
   const {writeConcern} = config.writeOptions;
   let connectOptions = {...config.connectOptions, writeConcern};
-
   // convert legacy connect options
   if('socketOptions' in config.connectOptions) {
     connectOptions = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,8 +58,8 @@ api.db = null;
 // shared collections cache
 api.collections = {};
 
-const {writeConcern} = bedrock.config.mongodb.writeOptions;
-
+// Note: api.writeOptions is deprecated
+// and will be removed in release 9.0
 // default database write options
 api.writeOptions = {...bedrock.config.mongodb.writeOptions};
 
@@ -163,7 +163,8 @@ api.openCollections = brCallbackify(async names => {
   const {writeConcern} = api.db.options;
   await Promise.all(unopened.map(async name => {
     // Note: We only pass `{writeConcern}` here to get around a bug in mongodb
-    // node driver 3.6.4 where `writeConcern` from `db` is not passed to collection
+    // node driver 3.6.4 where `writeConcern` from `db` is not passed to
+    // collection
     collections[name] = await api.db.collection(name, {writeConcern});
   }));
 
@@ -287,7 +288,7 @@ api.createIndexes = brCallbackify(async options => {
  * @return the new GridFSBucket instance
  */
 api.createGridFSBucket = options => {
-  const opts = Object.assign({}, {...api.writeOptions}, options);
+  const opts = {...options, ...api.writeOptions};
   return new mongo.GridFSBucket(api.db, opts);
 };
 
@@ -512,11 +513,12 @@ function _openDatabase(options, callback) {
           password: config.password
         };
       }
+
       // authSource should be set in connectOptions
       const opts = {
         ...config.authentication,
         ...config.connectOptions,
-        writeConcern
+        ...config.writeOptions,
       };
       let url = config.url;
       // if the user specified a connection URL use it
@@ -550,7 +552,7 @@ function _connect(options, callback) {
   if(!options.init) {
     logger.info('connecting to database: ' + _sanitizeUrl(options.url));
   }
-
+  const {writeConcern} = config.writeOptions;
   let connectOptions = {...config.connectOptions, writeConcern};
 
   // convert legacy connect options

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ api.collections = {};
 const {writeConcern} = bedrock.config.mongodb.writeOptions;
 
 // default database write options
-api.writeOptions = {...bedrock.config.mongodb.writeOptions, writeConcern};
+api.writeOptions = {...bedrock.config.mongodb.writeOptions};
 
 // load test config
 bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
@@ -162,6 +162,8 @@ api.openCollections = brCallbackify(async names => {
   const collections = {};
   const {writeConcern} = api.db.options;
   await Promise.all(unopened.map(async name => {
+    // FIXME: this is to get around a bug in mongodb node driver 3.6.4
+    // where the writeConcern from db is not being passed to collection
     collections[name] = await api.db.collection(name, {writeConcern});
   }));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ api.collections = {};
 // Note: api.writeOptions is deprecated
 // and will be removed in release 9.0
 // default database write options
-api.writeOptions = {...bedrock.config.mongodb.writeOptions};
+api.writeOptions = bedrock.config.mongodb.writeOptions;
 
 // load test config
 bedrock.events.on('bedrock.test.configure', () => require('./test.config'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,6 +160,7 @@ api.openCollections = brCallbackify(async names => {
   // open the collections
   logger.debug('opening collections', {collections: unopened});
   const collections = {};
+  const {writeConcern} = api.db.options;
   await Promise.all(unopened.map(async name => {
     collections[name] = await api.db.collection(name, {writeConcern});
   }));

--- a/lib/index.js
+++ b/lib/index.js
@@ -510,7 +510,11 @@ function _openDatabase(options, callback) {
         };
       }
       // authSource should be set in connectOptions
-      const opts = {...config.authentication, ...config.connectOptions, writeConcern};
+      const opts = {
+        ...config.authentication,
+        ...config.connectOptions,
+        writeConcern
+      };
       let url = config.url;
       // if the user specified a connection URL use it
       if(!url) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,8 +58,10 @@ api.db = null;
 // shared collections cache
 api.collections = {};
 
+const {writeConcern} = bedrock.config.mongodb;
+
 // default database write options
-api.writeOptions = bedrock.config.mongodb.writeOptions;
+api.writeOptions = {...bedrock.config.mongodb.writeOptions, writeConcern};
 
 // load test config
 bedrock.events.on('bedrock.test.configure', () => require('./test.config'));
@@ -131,7 +133,6 @@ function init(callback) {
 api.openCollections = brCallbackify(async names => {
   // remove collections that are already open
   const unopened = [];
-  const {writeConcern} = bedrock.config.mongodb;
   for(const name of names) {
     if(!(name in api.collections)) {
       unopened.push(name);
@@ -509,7 +510,7 @@ function _openDatabase(options, callback) {
         };
       }
       // authSource should be set in connectOptions
-      const opts = {...config.authentication, ...config.connectOptions};
+      const opts = {...config.authentication, ...config.connectOptions, writeConcern};
       let url = config.url;
       // if the user specified a connection URL use it
       if(!url) {
@@ -543,7 +544,7 @@ function _connect(options, callback) {
     logger.info('connecting to database: ' + _sanitizeUrl(options.url));
   }
 
-  let connectOptions = {...config.connectOptions};
+  let connectOptions = {...config.connectOptions, writeConcern};
 
   // convert legacy connect options
   if('socketOptions' in config.connectOptions) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,8 +162,8 @@ api.openCollections = brCallbackify(async names => {
   const collections = {};
   const {writeConcern} = api.db.options;
   await Promise.all(unopened.map(async name => {
-    // FIXME: this is to get around a bug in mongodb node driver 3.6.4
-    // where the writeConcern from db is not being passed to collection
+    // Note: We only pass `{writeConcern}` here to get around a bug in mongodb
+    // node driver 3.6.4 where `writeConcern` from `db` is not passed to collection
     collections[name] = await api.db.collection(name, {writeConcern});
   }));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ api.db = null;
 // shared collections cache
 api.collections = {};
 
-const {writeConcern} = bedrock.config.mongodb;
+const {writeConcern} = bedrock.config.mongodb.writeOptions;
 
 // default database write options
 api.writeOptions = {...bedrock.config.mongodb.writeOptions, writeConcern};

--- a/lib/index.js
+++ b/lib/index.js
@@ -282,7 +282,7 @@ api.createIndexes = brCallbackify(async options => {
  * @return the new GridFSBucket instance
  */
 api.createGridFSBucket = options => {
-  const opts = Object.assign({}, {writeConcern: api.writeOptions}, options);
+  const opts = Object.assign({}, {...api.writeOptions}, options);
   return new mongo.GridFSBucket(api.db, opts);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ api.openCollections = brCallbackify(async names => {
   await Promise.all(unopened.map(async name => {
     logger.debug('creating collection: ' + name);
     try {
-      await api.db.createCollection(name, {writeConcern});
+      await api.db.createCollection(name);
     } catch(e) {
       if(!api.isAlreadyExistsError(e)) {
         throw e;

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -12,15 +12,6 @@ config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
 config.mongodb.adminPrompt = true;
 
-config.mongodb.writeOptions = {
-  safe: true,
-  writeConcern: {
-    j: true,
-    w: 1
-  },
-  multi: true
-};
-
 // these settings are only effective if `test` is specified on the command line
 // when onInit = true, collections are dropped on initialization
 config.mongodb.dropCollections = {};

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -14,8 +14,10 @@ config.mongodb.adminPrompt = true;
 
 config.mongodb.writeOptions = {
   safe: true,
-  j: true,
-  w: 1,
+  writeConcern: {
+    j: true,
+    w: 1
+  },
   multi: true
 };
 


### PR DESCRIPTION
Updates our settings so we do not have deprecated uses of `w`, `j`, `wtimeout`, and `fsync`.

Those options now need to be inside of a `writeConcern` object.

This addresses:

https://github.com/digitalbazaar/bedrock-mongodb/issues/64


This is a draft PR until it can be confirmed it removes this deprecation error:

```js
Top-level use of w, wtimeout, j, and fsync is deprecated. Use writeConcern instead.
```

in multiple projects.

Removes deprecation warning in:

1. bedrock-mongodb
2. bedrock-edv-storage
3. bedrock-account