### PR TITLE
Use MongoClient result from _loginUser when adding user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-mongodb ChangeLog
 
+## 8.4.1 - TBD
+
+### Changed
+- Fix minor bug from async refactoring with `_loginUser` method.
+
 ## 8.4.0 - 2021-07-23
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -562,7 +562,7 @@ async function _connect(options) {
  * @param {object} options.opts - Options for the MongoClient.
  * @param {Server} options.url - A mongo connection string.
  *
- * @returns {Promise} The result of the connect.
+ * @returns {Promise<MongoClient>} The result of the connect.
 */
 async function _loginUser({auth, opts, url}) {
   return MongoClient.connect(url, {auth, ...opts});
@@ -591,7 +591,9 @@ async function _promptToCreateUser() {
   }
   const adminConfig = {...config, ...auth};
   const url = _createUrl(adminConfig);
-  const {client} = await _loginUser({auth, opts, url});
+
+  // this returns the client logged in as the admin
+  const client  = await _loginUser({auth, opts, url});
 
   // try to get server info to confirm proper authN as admin
   const db = client.db(auth.authSource);

--- a/lib/index.js
+++ b/lib/index.js
@@ -593,7 +593,7 @@ async function _promptToCreateUser() {
   const url = _createUrl(adminConfig);
 
   // this returns the client logged in as the admin
-  const client  = await _loginUser({auth, opts, url});
+  const client = await _loginUser({auth, opts, url});
 
   // try to get server info to confirm proper authN as admin
   const db = client.db(auth.authSource);


### PR DESCRIPTION
When adding a new user the new `async _loginUser` method now returns a fuil mongoDB client where previously it returned an object containing that client.

NOTE: this is a draft as I'm still testing the addUser functionality right now.