### PR TITLE
Do not await client.close do log error.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,7 @@ async function _initDatabase() {
     // credentials)
     if(client) {
       const force = true;
-      await client.close(force).catch(error => {
+      client.close(force).catch(error => {
         logger.error(
           'failed to close client used to initialize database', {error});
       });


### PR DESCRIPTION
https://github.com/digitalbazaar/bedrock-mongodb/issues/84

It looks like the code in the `finally` block executes before the `throw` in `catch` so we still try to close the connection, but we want to log the error still. Also of note:

```js
      await client.close(force).catch(error => {
        logger.error(
          'failed to close client used to initialize database', {error});
      });
```

not sure what happens you await a promise with a catch attached.