### PR TITLE
Remove authentication check

### DIFF
--- a/lib/authn.js
+++ b/lib/authn.js
@@ -5,11 +5,8 @@ import * as bedrock from '@bedrock/core';
 import * as urls from './urls.js';
 import {logger} from './logger.js';
 import mongo from 'mongodb';
-import semver from 'semver';
-import {klona} from 'klona';
 
 const {MongoClient} = mongo;
-const {util: {BedrockError}} = bedrock;
 
 export async function openDatabase(options) {
   const config = bedrock.config.mongodb;
@@ -22,20 +19,6 @@ export async function openDatabase(options) {
     writeOptions: {...config.writeOptions},
     ...options
   };
-
-  // do unauthenticated connection to mongo server to check
-  // server compatibility and authn requirements
-  const {admin} = await _getUnauthenticatedDb({config: klona(config)});
-  const serverInfo = await admin.serverInfo(null);
-  _checkServerVersion({serverInfo, config});
-
-  // check if server supports roles; if not, can't authenticate
-  if(!_usesRoles(serverInfo)) {
-    const stringVersion = serverInfo.versionArray.join('.');
-    throw new BedrockError(
-      `MongoDB server version "${stringVersion}" is unsupported.`,
-      'NotSupportedError');
-  }
 
   // if a username is defined create an auth object for Mongo;
   // otherwise `auth` will be passed as `null` and success will rely on other
@@ -93,56 +76,4 @@ async function _connect(options) {
     'database connection succeeded: db=' + options.database +
     ' username=' + connectOptions?.auth?.user, {ping});
   return {client, db};
-}
-
-function _usesRoles(serverInfo) {
-  // >= Mongo 2.6 uses user roles
-  return (
-    (serverInfo.versionArray[0] == 2 && serverInfo.versionArray[1] >= 6) ||
-    (serverInfo.versionArray[0] > 2));
-}
-
-/**
- * Establishes an unauthenticated connection to the server.
- *
- * @private
- * @param {object} options - Options to use.
- * @param {object} options.config - Config options.
- *
- * @returns {Promise<object>} Returns an object with the db and admin.
- */
-async function _getUnauthenticatedDb({config}) {
-  // only use the config stuff with out auth credentials
-  const opts = {
-    ...config.connectOptions,
-    ...config.writeOptions,
-  };
-  // if authSource is defined just delete it here
-  delete opts.authSource;
-  const urlParts = new URL(config.url || '');
-  // remove any parts of the url that could contain authorization data
-  const url = `${urlParts.protocol}//${urlParts.host}${urlParts.pathname}`;
-  const client = new MongoClient(url, opts);
-  await client.connect();
-  const db = client.db(config.name);
-  return {db, admin: db.admin()};
-}
-
-function _checkServerVersion({serverInfo, config}) {
-  // check that server version is supported
-  const {version} = serverInfo;
-  logger.info('connected to database', {
-    url: urls.sanitize(config.url),
-    version,
-  });
-  if(config.requirements.serverVersion &&
-    !semver.satisfies(version, config.requirements.serverVersion)) {
-    throw new BedrockError(
-      'Unsupported database version.',
-      'DatabaseError', {
-        url: urls.sanitize(config.url),
-        version,
-        required: config.requirements.serverVersion
-      });
-  }
 }

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -4,7 +4,6 @@
 import * as bedrock from '@bedrock/core';
 import * as urls from './urls.js';
 import {logger} from './logger.js';
-import {MDBE_AUTHZ_FAILED} from './exceptions.js';
 import mongo from 'mongodb';
 import semver from 'semver';
 import {klona} from 'klona';
@@ -37,14 +36,11 @@ export async function openDatabase(options) {
       `MongoDB server version "${stringVersion}" is unsupported.`,
       'NotSupportedError');
   }
-  // makes an unauthenticated call to the server
-  // to see if auth is required
-  const authRequired = await _isAuthnRequired({config, admin});
 
-  // if authRequired create an auth object for Mongo;
+  // if a username is defined create an auth object for Mongo;
   // otherwise `auth` will be passed as `null` and success will rely on other
   // config options such as the url for the server
-  if(authRequired) {
+  if(config.username) {
     opts.connectOptions.auth = {
       user: config.username,
       password: config.password
@@ -104,36 +100,6 @@ function _usesRoles(serverInfo) {
   return (
     (serverInfo.versionArray[0] == 2 && serverInfo.versionArray[1] >= 6) ||
     (serverInfo.versionArray[0] > 2));
-}
-
-/**
- * Determines if authn is required.
- *
- * @see
- * https://mongodb.github.io/node-mongodb-native/3.7/api/Admin.html
- * #listDatabases
- * @private
- * @param {object} options - Options to use.
- * @param {object} options.config - The mongodb config.
- * @param {object} options.admin - A Mongo driver Admin class.
- *
- * @returns {Promise<boolean>} Is authRequired?
- */
-async function _isAuthnRequired({config, admin}) {
-  if(config.forceAuthentication) {
-    return true;
-  }
-  try {
-    // if listing databases fails on authz, then authentication is required
-    await admin.listDatabases();
-  } catch(e) {
-    if(e?.code === MDBE_AUTHZ_FAILED) {
-      return true;
-    }
-    // some other error, abort
-    throw e;
-  }
-  return false;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-mongodb",
   "dependencies": {
-    "klona": "^2.0.5",
     "mongodb": "^3.7.3",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
Removes the authentication check
Removes the serverVersion check
Removes the uses roles check
No unauthenticated connections to the server are made before trying to connect.

_This should fix issues with mongodb atlas which does not allow unauthenticated connections at all._