### PR TITLE
Make checks optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
       env:
         MONGODB_USERNAME: root
         MONGODB_PASSWORD: example
+        MONGODB_AUTHSOURCE: admin
 
   coverage:
     needs: [test-node]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # bedrock-mongodb ChangeLog
 
-## 10.1.1 -
+## 10.0.1 -
 
 ### Fixed
 - No longer pass in `authSource: undefined` as this causes connection strings with auth to fail.
-- No longer pass in other undefined connectOptions.
-
-### Added
-- Added a new config option `checkServerDetails` that allows you to skip auth, server
-  version, & role checks.
+- No longer pass in other `ssl: undefined` in connectOptions.
 
 ## 10.0.1 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # bedrock-mongodb ChangeLog
 
-## 10.1.0 -
+## 10.1.1 -
+
+### Fixed
+- No longer pass in `authSource: undefined` as this causes connection strings to fail.
+- No longer pass in `ssl: undefined` as Mongo defaults to `ssl: true`.
 
 ### Added
 - Added a new config option `skipChecks` that allows you to skip auth, server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 10.1.1 -
 
 ### Fixed
-- No longer pass in `authSource: undefined` as this causes connection strings to fail.
-- No longer pass in `ssl: undefined` as Mongo defaults to `ssl: true`.
+- No longer pass in `authSource: undefined` as this causes connection strings with auth to fail.
+- No longer pass in other undefined connectOptions.
 
 ### Added
 - Added a new config option `skipChecks` that allows you to skip auth, server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - No longer pass in other undefined connectOptions.
 
 ### Added
-- Added a new config option `skipChecks` that allows you to skip auth, server
+- Added a new config option `checkServerDetails` that allows you to skip auth, server
   version, & role checks.
 
 ## 10.0.1 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Fixed
 - No longer pass in `authSource: undefined` as this causes connection strings with auth to fail.
 - No longer pass in `ssl: undefined` in connectOptions.
-- Use `db.databaseName` when logging connection success over `config.name`. 
-- Allow Mongo Driver to infer the database being connected to over using `config.name`.
+- Use `db.databaseName` when logging connection success over `config.name`.
 
 ## 10.0.1 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-mongodb ChangeLog
 
-## 10.0.1 -
+## 10.0.2 -
 
 ### Fixed
 - No longer pass in `authSource: undefined` as this causes connection strings with auth to fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-mongodb ChangeLog
 
+## 10.1.0 -
+
+### Added
+- Added a new config option `skipChecks` that allows you to skip auth, server
+  version, & role checks.
+
 ## 10.0.1 -
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixed
 - No longer pass in `authSource: undefined` as this causes connection strings with auth to fail.
-- No longer pass in other `ssl: undefined` in connectOptions.
+- No longer pass in `ssl: undefined` in connectOptions.
+- Use `db.databaseName` when logging connection success over `config.name`. 
+- Allow Mongo Driver to infer the database being connected to over using `config.name`.
 
 ## 10.0.1 -
 

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -24,7 +24,7 @@ export async function openDatabase(options) {
     ...options
   };
 
-  // if the user specified a connection URL use it
+  // if a `url` was not specified, create one from the `config`
   if(!opts.url) {
     opts.url = urls.create(config);
   }

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -88,7 +88,7 @@ async function _connect(options) {
     delete connectOptions.socketOptions;
   }
   const client = await MongoClient.connect(options.url, connectOptions);
-  const db = client.db(options.database);
+  const db = client.db();
   const ping = await db.admin().ping();
   logger.debug(
     'database connection succeeded: db=' + options.database +
@@ -167,7 +167,7 @@ async function _getUnauthenticatedDb({config}) {
   const url = `${urlParts.protocol}//${urlParts.host}${urlParts.pathname}`;
   const client = new MongoClient(url, opts);
   await client.connect();
-  const db = client.db(config.name);
+  const db = client.db();
   return {db, admin: db.admin()};
 }
 

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -29,7 +29,7 @@ export async function openDatabase(options) {
     opts.url = urls.create(config);
   }
 
-  if(!config.skipChecks) {
+  if(config.skipChecks) {
     if(config.username || config.password) {
       _addAuthOptions({options: opts, config});
     }

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -23,23 +23,25 @@ export async function openDatabase(options) {
     writeOptions: {...config.writeOptions},
     ...options
   };
+  let authRequired = config.username && config.password;
+  if(config.skipChecks === false) {
+    // do unauthenticated connection to mongo server to check
+    // server compatibility and authn requirements
+    const {admin} = await _getUnauthenticatedDb({config: klona(config)});
+    const serverInfo = await admin.serverInfo(null);
+    _checkServerVersion({serverInfo, config});
 
-  // do unauthenticated connection to mongo server to check
-  // server compatibility and authn requirements
-  const {admin} = await _getUnauthenticatedDb({config: klona(config)});
-  const serverInfo = await admin.serverInfo(null);
-  _checkServerVersion({serverInfo, config});
-
-  // check if server supports roles; if not, can't authenticate
-  if(!_usesRoles(serverInfo)) {
-    const stringVersion = serverInfo.versionArray.join('.');
-    throw new BedrockError(
-      `MongoDB server version "${stringVersion}" is unsupported.`,
-      'NotSupportedError');
+    // check if server supports roles; if not, can't authenticate
+    if(!_usesRoles(serverInfo)) {
+      const stringVersion = serverInfo.versionArray.join('.');
+      throw new BedrockError(
+        `MongoDB server version "${stringVersion}" is unsupported.`,
+        'NotSupportedError');
+    }
+    // makes an unauthenticated call to the server
+    // to see if auth is required
+    authRequired = await _isAuthnRequired({config, admin});
   }
-  // makes an unauthenticated call to the server
-  // to see if auth is required
-  const authRequired = await _isAuthnRequired({config, admin});
 
   // if authRequired create an auth object for Mongo;
   // otherwise `auth` will be passed as `null` and success will rely on other

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -134,7 +134,7 @@ function _addAuthOptions({options, config}) {
   // authSource is the database to authenticate against
   // this is usually `admin` in dev and a specific db in production
   options.connectOptions.authSource =
-    config.connectOptions.authSource || options.name;
+    config.connectOptions.authSource || options.database;
   return options;
 }
 

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -29,7 +29,7 @@ export async function openDatabase(options) {
     opts.url = urls.create(config);
   }
 
-  if(config.skipChecks) {
+  if(!config.checkServerDetails) {
     if(config.username || config.password) {
       _addAuthOptions({options: opts, config});
     }

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -29,13 +29,6 @@ export async function openDatabase(options) {
     opts.url = urls.create(config);
   }
 
-  if(!config.checkServerDetails) {
-    if(config.username || config.password) {
-      _addAuthOptions({options: opts, config});
-    }
-    // connect to database and get server info
-    return _connect(opts);
-  }
   // do unauthenticated connection to mongo server to check
   // server compatibility and authn requirements
   const {admin} = await _getUnauthenticatedDb({config: klona(config)});

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -23,49 +23,45 @@ export async function openDatabase(options) {
     writeOptions: {...config.writeOptions},
     ...options
   };
-  let authRequired = config.username && config.password;
-  if(!config.skipChecks) {
-    // do unauthenticated connection to mongo server to check
-    // server compatibility and authn requirements
-    const {admin} = await _getUnauthenticatedDb({config: klona(config)});
-    const serverInfo = await admin.serverInfo(null);
-    _checkServerVersion({serverInfo, config});
-
-    // check if server supports roles; if not, can't authenticate
-    if(!_usesRoles(serverInfo)) {
-      const stringVersion = serverInfo.versionArray.join('.');
-      throw new BedrockError(
-        `MongoDB server version "${stringVersion}" is unsupported.`,
-        'NotSupportedError');
-    }
-    // makes an unauthenticated call to the server
-    // to see if auth is required
-    authRequired = await _isAuthnRequired({config, admin});
-  }
-
-  // if authRequired create an auth object for Mongo;
-  // otherwise `auth` will be passed as `null` and success will rely on other
-  // config options such as the url for the server
-  if(authRequired) {
-    opts.connectOptions.auth = {
-      user: config.username,
-      password: config.password
-    };
-    // authSource is the database to authenticate against
-    // this is usually `admin` in dev and a specific db in production
-    opts.connectOptions.authSource =
-      config.connectOptions.authSource || options.name;
-  }
 
   // if the user specified a connection URL use it
   if(!opts.url) {
     opts.url = urls.create(config);
   }
 
-  // connect to database and get server info
-  const connectResult = await _connect(opts);
+  if(!config.skipChecks) {
+    if(config.username || config.password) {
+      _addAuthOptions({options: opts, config});
+    }
+    // connect to database and get server info
+    return _connect(opts);
+  }
+  // do unauthenticated connection to mongo server to check
+  // server compatibility and authn requirements
+  const {admin} = await _getUnauthenticatedDb({config: klona(config)});
+  const serverInfo = await admin.serverInfo(null);
+  _checkServerVersion({serverInfo, config});
 
-  return connectResult;
+  // check if server supports roles; if not, can't authenticate
+  if(!_usesRoles(serverInfo)) {
+    const stringVersion = serverInfo.versionArray.join('.');
+    throw new BedrockError(
+      `MongoDB server version "${stringVersion}" is unsupported.`,
+      'NotSupportedError');
+  }
+  // makes an unauthenticated call to the server
+  // to see if auth is required
+  const authRequired = await _isAuthnRequired({config, admin});
+
+  // if authRequired create an auth object for Mongo;
+  // otherwise `auth` will be passed as `null` and success will rely on other
+  // config options such as the url for the server
+  if(authRequired) {
+    _addAuthOptions({options: opts, config});
+  }
+
+  // connect to database and get server info
+  return _connect(opts);
 }
 
 /**
@@ -135,6 +131,18 @@ async function _isAuthnRequired({config, admin}) {
     throw e;
   }
   return false;
+}
+
+function _addAuthOptions({options, config}) {
+  options.connectOptions.auth = {
+    user: config.username,
+    password: config.password
+  };
+  // authSource is the database to authenticate against
+  // this is usually `admin` in dev and a specific db in production
+  options.connectOptions.authSource =
+    config.connectOptions.authSource || options.name;
+  return options;
 }
 
 /**

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -24,7 +24,7 @@ export async function openDatabase(options) {
     ...options
   };
   let authRequired = config.username && config.password;
-  if(config.skipChecks === false) {
+  if(!config.skipChecks) {
     // do unauthenticated connection to mongo server to check
     // server compatibility and authn requirements
     const {admin} = await _getUnauthenticatedDb({config: klona(config)});
@@ -77,7 +77,6 @@ export async function openDatabase(options) {
  * @returns {Promise<object>} Returns the client & db.
  */
 async function _connect(options) {
-
   if(!options.init) {
     logger.info('connecting to database: ' + urls.sanitize(options.url));
   }

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -84,7 +84,7 @@ async function _connect(options) {
   const db = client.db();
   const ping = await db.admin().ping();
   logger.debug(
-    'database connection succeeded: db=' + options.database +
+    'database connection succeeded: db=' + db.databaseName +
     ' username=' + connectOptions?.auth?.user, {ping});
   return {client, db};
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,10 @@ config.mongodb.connectOptions = {
   useNewUrlParser: true,
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
+  // ssl defaults to true on the mongo client
+  // ssl: false
+  // authSource can be set here too
+  // authSource: admin
 };
 
 // this is used when writing to the database

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,9 +44,11 @@ config.mongodb.connectOptions = {
   useNewUrlParser: true,
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
-  // FIXME: we need development and production servers to use SSL
+  // it is recommended to set either ssl or tls to true in production
   // ssl: true
-  // authSource should be set here
+  // tls: true
+  // authSource is the database you authenticate against
+  // it often needs to be set explicitly
   // authSource: 'admin'
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,10 +47,10 @@ config.mongodb.connectOptions = {
   useNewUrlParser: true,
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
-  // ssl defaults to true on the mongo client
-  // ssl: false
-  // authSource can be set here too
-  // authSource: admin
+  // FIXME: we need development and production servers to use SSL
+  // ssl: true
+  // authSource should be set here
+  // authSource: 'admin'
 };
 
 // this is used when writing to the database

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,7 +36,9 @@ config.mongodb.authentication = {
   // used by MongoDB < 3.0
   // authMechanism: 'MONGODB-CR'
 };
-
+// if true role, server version, & authn checks are skipped
+// this is appears to be necessary on some mongo servers
+config.mongodb.skipChecks = false;
 // this is used when making connections to the database
 config.mongodb.connectOptions = {
   useUnifiedTopology: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,7 +61,7 @@ config.mongodb.writeOptions = {
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string
-config.mongodb.requirements.serverVersion = '>=4.4';
+config.mongodb.requirements.serverVersion = '>=4.2';
 
 // this is used by _createUser to add a user as an admin to a collection
 // config.mongodb.collection = 'admin-collection';

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,11 +45,6 @@ config.mongodb.connectOptions = {
   serverSelectionTimeoutMS: 30000,
   autoReconnect: false,
   useNewUrlParser: true,
-  // the db to authenticate against
-  authSource: undefined,
-  // we use the default for ssl
-  // set this to true if you want to require ssl
-  ssl: undefined,
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,9 +36,6 @@ config.mongodb.authentication = {
   // used by MongoDB < 3.0
   // authMechanism: 'MONGODB-CR'
 };
-// if false role, server version, & authn checks are skipped
-// this is appears to be necessary on some mongo servers
-config.mongodb.checkServerDetails = true;
 // this is used when making connections to the database
 config.mongodb.connectOptions = {
   useUnifiedTopology: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -64,7 +64,7 @@ config.mongodb.writeOptions = {
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string
-config.mongodb.requirements.serverVersion = '>=4.2';
+config.mongodb.requirements.serverVersion = '>=4.4';
 
 // this is used by _createUser to add a user as an admin to a collection
 // config.mongodb.collection = 'admin-collection';

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,9 +36,9 @@ config.mongodb.authentication = {
   // used by MongoDB < 3.0
   // authMechanism: 'MONGODB-CR'
 };
-// if true role, server version, & authn checks are skipped
+// if false role, server version, & authn checks are skipped
 // this is appears to be necessary on some mongo servers
-config.mongodb.skipChecks = false;
+config.mongodb.checkServerDetails = true;
 // this is used when making connections to the database
 config.mongodb.connectOptions = {
   useUnifiedTopology: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,8 @@ async function _initDatabase() {
         // auth failed, either DB didn't exist or bad credentials
         logger.info('database authentication failed:' +
           ' db=' + config.name +
-          ' username=' + config.username);
+          ' username=' + config.username +
+          ' url=' + urls.sanitize(config.url));
       }
       throw new BedrockError(
         'Could not initialize database.',

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,15 +7,27 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const convertToBoolean = (envVariable = '') => {
+  if(/^(1|true)$/.test(envVariable)) {
+    return true;
+  }
+  return false;
+};
+
 // MongoDB
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
-// set the env variable to 1 or make these true
-// don't set the env variable for false
-config.mongodb.checkServerDetails =
-  Boolean(process.env.MONGODB_SKIPCHECKS) || true;
-config.mongodb.connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
+// set the env variable to 1 or true to make these true
+// set the env variable to anything else to make them false
+
+if(process.env.MONGODB_SKIPCHECKS) {
+  config.mongodb.checkServerDetails =
+    convertToBoolean(process.env.MONGODB_SKIPCHECKS);
+}
+if(process.env.MONGODB_SSL) {
+  config.mongodb.connectOptions.ssl = convertToBoolean(process.env.MONGODB_SSL);
+}
 // used for testing url only connections
 config.mongodb.url = process.env.MONGODB_URL;
 // this can safely be undefined

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -26,14 +26,20 @@ if(process.env.MONGODB_TLS) {
 if(process.env.MONGODB_AUTHSOURCE) {
   connectOptions.authSource = process.env.MONGODB_AUTHSOURCE;
 }
-
-// used for testing url only connections
-config.mongodb.url = process.env.MONGODB_URL;
-// this can safely be undefined
-connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
-
-config.mongodb.username = process.env.MONGODB_USERNAME;
-config.mongodb.password = process.env.MONGODB_PASSWORD;
+if(process.env.MONGODB_URL) {
+  // used for testing url only connections
+  config.mongodb.url = process.env.MONGODB_URL;
+}
+if(process.env.MONGODB_REPLICASET) {
+  // this can safely be undefined
+  connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
+}
+if(process.env.MONGODB_USERNAME) {
+  config.mongodb.username = process.env.MONGODB_USERNAME;
+}
+if(process.env.MONGODB_PASSWORD) {
+  config.mongodb.password = process.env.MONGODB_PASSWORD;
+}
 
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -22,13 +22,16 @@ config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
 // set the env variable to 1 or true to make these true
 // set the env variable to anything else to make them false
-if(process.env.MONGODB_CHECK_SERVER_DETAILS) {
-  config.mongodb.checkServerDetails =
-    convertToBoolean(process.env.MONGODB_CHECK_SERVER_DETAILS);
-}
 if(process.env.MONGODB_SSL) {
   connectOptions.ssl = convertToBoolean(process.env.MONGODB_SSL);
 }
+if(process.env.MONGODB_TLS) {
+  connectOptions.tls = convertToBoolean(process.env.MONGODB_TLS);
+}
+if(process.env.MONGODB_AUTHSOURCE) {
+  connectOptions.authSource = process.env.MONGODB_AUTHSOURCE;
+}
+
 // used for testing url only connections
 config.mongodb.url = process.env.MONGODB_URL;
 // this can safely be undefined
@@ -36,9 +39,6 @@ connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 
 config.mongodb.username = process.env.MONGODB_USERNAME;
 config.mongodb.password = process.env.MONGODB_PASSWORD;
-if(process.env.MONGODB_AUTHSOURCE) {
-  connectOptions.authSource = process.env.MONGODB_AUTHSOURCE;
-}
 
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -20,10 +20,9 @@ config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
 // set the env variable to 1 or true to make these true
 // set the env variable to anything else to make them false
-
-if(process.env.MONGODB_SKIPCHECKS) {
+if(process.env.MONGODB_CHECK_SERVER_DETAILS) {
   config.mongodb.checkServerDetails =
-    convertToBoolean(process.env.MONGODB_SKIPCHECKS);
+    convertToBoolean(process.env.MONGODB_CHECK_SERVER_DETAILS);
 }
 if(process.env.MONGODB_SSL) {
   config.mongodb.connectOptions.ssl = convertToBoolean(process.env.MONGODB_SSL);

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -11,11 +11,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
+// set the env variable to 1 or make these true
+// don't set the env variable for false
 config.mongodb.skipChecks = Boolean(process.env.MONGODB_SKIPCHECKS) || false;
+config.mongodb.connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
 // used for testing url only connections
 config.mongodb.url = process.env.MONGODB_URL;
-// process.env.MONGODB_SSL should be 1 to test with SSL
-config.mongodb.connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
 // this can safely be undefined
 config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,12 +7,7 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const convertToBoolean = (envVariable = '') => {
-  if(/^(1|true)$/.test(envVariable)) {
-    return true;
-  }
-  return false;
-};
+const convertToBoolean = (envVariable = '') => /^(1|true)$/.test(envVariable);
 
 const {connectOptions} = config.mongodb;
 

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -13,7 +13,8 @@ config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
 // set the env variable to 1 or make these true
 // don't set the env variable for false
-config.mongodb.skipChecks = Boolean(process.env.MONGODB_SKIPCHECKS) || false;
+config.mongodb.checkServerDetails =
+  Boolean(process.env.MONGODB_SKIPCHECKS) || true;
 config.mongodb.connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
 // used for testing url only connections
 config.mongodb.url = process.env.MONGODB_URL;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -14,6 +14,8 @@ const convertToBoolean = (envVariable = '') => {
   return false;
 };
 
+const {connectOptions} = config.mongodb;
+
 // MongoDB
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
@@ -25,27 +27,19 @@ if(process.env.MONGODB_CHECK_SERVER_DETAILS) {
     convertToBoolean(process.env.MONGODB_CHECK_SERVER_DETAILS);
 }
 if(process.env.MONGODB_SSL) {
-  config.mongodb.connectOptions.ssl = convertToBoolean(process.env.MONGODB_SSL);
+  connectOptions.ssl = convertToBoolean(process.env.MONGODB_SSL);
 }
 // used for testing url only connections
 config.mongodb.url = process.env.MONGODB_URL;
 // this can safely be undefined
-config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
+connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 
-if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
-  config.mongodb.username = process.env.MONGODB_USERNAME;
-  config.mongodb.password = process.env.MONGODB_PASSWORD;
-  const {connectOptions} = config.mongodb;
-  connectOptions.authSource = process.env.MONGODB_AUTHSOURCE || 'admin';
-  console.log(
-    'TESTING WITH AUTH ', {
-      username: config.mongodb.username,
-      authSource: connectOptions.authSource,
-      password: Boolean(config.mongodb.password),
-      ssl: connectOptions.ssl,
-      replicaSet: connectOptions.replicaSet
-    });
+config.mongodb.username = process.env.MONGODB_USERNAME;
+config.mongodb.password = process.env.MONGODB_PASSWORD;
+if(process.env.MONGODB_AUTHSOURCE) {
+  connectOptions.authSource = process.env.MONGODB_AUTHSOURCE;
 }
+
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -11,16 +11,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
 config.mongodb.port = process.env.MONGODB_PORT || 27017;
+config.mongodb.skipChecks = Boolean(process.env.MONGODB_SKIPCHECKS) || false;
+// used for testing url only connections
+config.mongodb.url = process.env.MONGODB_URL;
+// process.env.MONGODB_SSL should be 1 to test with SSL
+config.mongodb.connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
+// this can safely be undefined
+config.mongodb.connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
 
 if(process.env.MONGODB_USERNAME && process.env.MONGODB_PASSWORD) {
   config.mongodb.username = process.env.MONGODB_USERNAME;
   config.mongodb.password = process.env.MONGODB_PASSWORD;
   const {connectOptions} = config.mongodb;
-  // process.env.MONGODB_SSL should be 1 to test with SSL
-  connectOptions.ssl = Boolean(process.env.MONGODB_SSL) || false;
   connectOptions.authSource = process.env.MONGODB_AUTHSOURCE || 'admin';
-  // this can safely be undefined
-  connectOptions.replicaSet = process.env.MONGODB_REPLICASET;
   console.log(
     'TESTING WITH AUTH ', {
       username: config.mongodb.username,


### PR DESCRIPTION
Adds a new feature `checkServerDetails` allowing mongodb atlas connections to occur with out authn, role, or server version checks.

I was able to connect to a mongodb atlas instance using this branch and just a connectString with the password in the connect string.

This is a minor release so that our implementations of the mongodb 3.0 driver works on Atlas.

Confirmation that using `db.databaseName` works:

```js
2022-08-29T15:24:57.159Z - debug: [bedrock-mongodb] database connection succeeded: db=bedrock_mongodb_test username=undefined workerPid=17100, workerId=
```