### PR TITLE
Minor Release: fix url create & add ability to configure `protocol` for replicaSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # bedrock-mongodb ChangeLog
 
 ## 10.0.2 -
-## Fixed
-- Do not add `config.port` to connection url if it is not a valid port.
+### Fixed
+- Throw if `config.port` is invalid.
+- Ignore `config.port` if it's `undefined` or `null`.
 
 ## 10.0.1 - 2022-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # bedrock-mongodb ChangeLog
 
-## 10.0.2 -
+## 10.1.1 -
 ### Fixed
 - Throw if `config.port` is invalid.
 - Ignore `config.port` if it's `undefined` or `null`.
+
+### Added
+- A new config option `config.protocol` which allows connections to replicateSets using `mongodb+srv`.
 
 ## 10.0.1 - 2022-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock-mongodb ChangeLog
 
+## 10.0.2 -
+## Fixed
+- Do not add `config.port` to connection url if it is not a valid port.
+
 ## 10.0.1 - 2022-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import * as database from '@bedrock/mongodb';
 // custom configuration
 bedrock.config.mongodb.name = 'my_project_dev'; // default: bedrock_dev
 bedrock.config.mongodb.host = 'localhost';      // default: localhost
+bedrock.config.mongodb.protocol = 'mongodb'; // default: mongodb
 bedrock.config.mongodb.port = 27017;            // default: 27017
 bedrock.config.mongodb.username = 'my_project'; // default: bedrock
 bedrock.config.mongodb.password = 'password';   // default: password
@@ -71,6 +72,7 @@ import {config} from '@bedrock/core';
 
 config.mongodb.username = 'me';
 config.mongodb.password = 'password';
+config.mongodb.protocol = 'mongodb+srv';
 const {connectOptions} = config.mongodb;
 // optional, only required if connecting to a replicaSet
 connectOptions.replicaSet = 'my_provider_replica_set';

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,7 @@ config.mongodb = {};
 config.mongodb.name = 'bedrock_dev';
 config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
+config.mongodb.protocol = 'mongodb';
 config.mongodb.username = undefined;
 config.mongodb.password = undefined;
 config.mongodb.adminPrompt = true;

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -26,7 +26,7 @@ export function create(config) {
  * @returns {boolean} If it is a valid TCP port.
  */
 function assertTCPPort(port) {
-  return Number.parseInt(port) > 1;
+  return Number.parseInt(port) >= 1;
 }
 
 export function sanitize(path) {

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2012-2022 Digital Bazaar, Inc. All rights reserved.
  */
 export function create(config) {
-  let url = 'mongodb://';
+  let url = `${config.protocol}://`;
   if(config.username) {
     url += `${config.username}:${config.password}@`;
   }

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -6,12 +6,27 @@ export function create(config) {
   if(config.username) {
     url += `${config.username}:${config.password}@`;
   }
-  url += `${config.host}:${config.port}/${config.name}`;
+  url += config.host;
+  if(assertTCPPort(config.port)) {
+    url += `:${config.port}`;
+  }
+  url += `/${config.name}`;
   // this needs to come last
   if(config.username) {
     url += `?authSource=${config.connectOptions.authSource || 'admin'}`;
   }
   return url;
+}
+
+/**
+ * Tests if the config.port is a valid TCP Port.
+ *
+ * @param {string|number} port - The config.port.
+ *
+ * @returns {boolean} If it is a valid TCP port.
+ */
+function assertTCPPort(port) {
+  return Number.parseInt(port) > 1;
 }
 
 export function sanitize(path) {

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -7,15 +7,35 @@ export function create(config) {
     url += `${config.username}:${config.password}@`;
   }
   url += config.host;
-  if(assertPort(config.port)) {
-    url += `:${config.port}`;
-  }
+  url += _addPort(config.port);
   url += `/${config.name}`;
   // this needs to come last
   if(config.username) {
     url += `?authSource=${config.connectOptions.authSource || 'admin'}`;
   }
   return url;
+}
+
+/**
+ * Adds a port to the url provided the port is valid.
+ *
+ * @private
+ *
+ * @param {number|string} port - The port of the server.
+ *
+ * @throws {TypeError} Throws if the port is not a number gte 1.
+ *
+ * @returns {string} - The resulting port.
+ */
+function _addPort(port) {
+  if(port === null || port === undefined) {
+    return '';
+  }
+  if(!assertPort(port)) {
+    throw new TypeError(
+      `Expected port to be a number greater than 0 received ${port}`);
+  }
+  return `:${port}`;
 }
 
 /**

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -25,7 +25,7 @@ export function create(config) {
  *
  * @returns {boolean} If it is a valid TCP port.
  */
-function assertTCPPort(port) {
+function assertPort(port) {
   return Number.parseInt(port) >= 1;
 }
 

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -7,7 +7,7 @@ export function create(config) {
     url += `${config.username}:${config.password}@`;
   }
   url += config.host;
-  if(assertTCPPort(config.port)) {
+  if(assertPort(config.port)) {
     url += `:${config.port}`;
   }
   url += `/${config.name}`;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -19,6 +19,9 @@ if(process.env.MONGODB_PORT) {
   config.mongodb.port = assertNull(process.env.MONGODB_PORT) ?
     null : process.env.MONGODB_PORT;
 }
+if(process.env.MONGODB_PROTOCOL) {
+  config.mongodb.protocol = process.env.MONGODB_PROTOCOL;
+}
 // set the env variable to 1 or true to make these true
 // set the env variable to anything else to make them false
 if(process.env.MONGODB_SSL) {

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -7,14 +7,18 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const convertToBoolean = (envVariable = '') => /^(1|true)$/.test(envVariable);
+const convertToBoolean = (envVariable = '') => /^(1|true)$/i.test(envVariable);
+const assertNull = envVariable => /^null$/i.test(envVariable);
 
 const {connectOptions} = config.mongodb;
 
 // MongoDB
 config.mongodb.name = 'bedrock_mongodb_test';
 config.mongodb.host = process.env.MONGODB_HOST || 'localhost';
-config.mongodb.port = process.env.MONGODB_PORT || 27017;
+if(process.env.MONGODB_PORT) {
+  config.mongodb.port = assertNull(process.env.MONGODB_PORT) ?
+    null : process.env.MONGODB_PORT;
+}
 // set the env variable to 1 or true to make these true
 // set the env variable to anything else to make them false
 if(process.env.MONGODB_SSL) {


### PR DESCRIPTION
Adds a pretty basic check to ensure that the port is a valid TCP port before adding it to a connection string. This is useful in the edge case where someone is accessing a mongo server over `https` or using an atlas cluster that does not contain a port and wants to connect using the config object only. This is for release 10 of the library.

In order to allow connections to replicaSets with out a url being specified we now allow the protocol to be configured. For replicateSets the protocol needs to be `mongodb+srv`.

See: https://www.mongodb.com/developer/products/mongodb/srv-connection-strings/

For more information.

This was tested and I was able to connect to a replicaSet using this config:

```js
{
  // this is the resulting url
  url: 'mongodb+srv://username:password@clustersomething.9gqecyt.mongodb.net/bedrock_mongodb_test?authSource=admin',
  // this is the config that was passed to `urls.create`
  config: {
    name: 'bedrock_mongodb_test',
    host: '<redacted>.9gqecyt.mongodb.net',
    port: null,
    protocol: 'mongodb+srv',
    username: '<redacted>',
    password: '<redacted>',
    adminPrompt: true,
    forceAuthentication: false,
    authentication: {},
    connectOptions: {
      useUnifiedTopology: true,
      serverSelectionTimeoutMS: 30000,
      autoReconnect: false,
      useNewUrlParser: true,
      promoteBuffers: true
    },
    writeOptions: { writeConcern: [Object], forceServerObjectId: true },
    requirements: { serverVersion: '>=4.2' },
    dropCollections: { onInit: true, collections: [] }
  }
}
```