### PR TITLE
Mongo 4 no roles check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-mongodb ChangeLog
 
+## 11.0.0 -
+
+### Removed
+- **BREAKING**: Remove roles check from authn.
+
+### Added
+- **BREAKING**: Throw if server version is less than 2.6.
+
 ## 10.1.1 -
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **BREAKING**: Remove roles check from authn.
 
 ### Added
-- **BREAKING**: Throw if server version is less than 2.6.
+- **BREAKING**: Throw if server version is less than 3.6.
 
 ## 10.1.1 -
 

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -35,13 +35,6 @@ export async function openDatabase(options) {
   const serverInfo = await admin.serverInfo(null);
   _checkServerVersion({serverInfo, config});
 
-  // check if server supports roles; if not, can't authenticate
-  if(!_usesRoles(serverInfo)) {
-    const stringVersion = serverInfo.versionArray.join('.');
-    throw new BedrockError(
-      `MongoDB server version "${stringVersion}" is unsupported.`,
-      'NotSupportedError');
-  }
   // makes an unauthenticated call to the server
   // to see if auth is required
   const authRequired = await _isAuthnRequired({config, admin});
@@ -87,13 +80,6 @@ async function _connect(options) {
     'database connection succeeded: db=' + db.databaseName +
     ' username=' + connectOptions?.auth?.user, {ping});
   return {client, db};
-}
-
-function _usesRoles(serverInfo) {
-  // >= Mongo 2.6 uses user roles
-  return (
-    (serverInfo.versionArray[0] == 2 && serverInfo.versionArray[1] >= 6) ||
-    (serverInfo.versionArray[0] > 2));
 }
 
 /**

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -128,7 +128,7 @@ async function _isAuthnRequired({config, admin}) {
 
 function _addAuthOptions({options, config}) {
   options.connectOptions.auth = {
-    user: config.username,
+    username: config.username,
     password: config.password
   };
   // authSource is the database to authenticate against

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -156,11 +156,22 @@ function _checkServerVersion({serverInfo, config}) {
     url: urls.sanitize(config.url),
     version,
   });
+  // if the server is not at least 2.6.0 throw
+  // as we do require roles / authn
+  if(!semver.gte(version, '2.6.0')) {
+    throw new BedrockError(
+      'Unsupported database version.',
+      'NotSupportedError', {
+        url: urls.sanitize(config.url),
+        version,
+        required: '>= 2.6.0'
+      });
+  }
   if(config.requirements.serverVersion &&
     !semver.satisfies(version, config.requirements.serverVersion)) {
     throw new BedrockError(
       'Unsupported database version.',
-      'DatabaseError', {
+      'NotSupportedError', {
         url: urls.sanitize(config.url),
         version,
         required: config.requirements.serverVersion

--- a/lib/authn.js
+++ b/lib/authn.js
@@ -156,15 +156,15 @@ function _checkServerVersion({serverInfo, config}) {
     url: urls.sanitize(config.url),
     version,
   });
-  // if the server is not at least 2.6.0 throw
-  // as we do require roles / authn
-  if(!semver.gte(version, '2.6.0')) {
+  // if the server is not at least 3.6.0 throw
+  // as mongo node driver 4 only supports 3.6.0 and higher
+  if(!semver.gte(version, '3.6.0')) {
     throw new BedrockError(
       'Unsupported database version.',
       'NotSupportedError', {
         url: urls.sanitize(config.url),
         version,
-        required: '>= 2.6.0'
+        required: '>= 3.6.0'
       });
   }
   if(config.requirements.serverVersion &&

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,6 +42,7 @@ config.mongodb.connectOptions = {
   serverSelectionTimeoutMS: 30000,
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
+  forceServerObjectId: true,
   // it is recommended to set either ssl or tls to true in production
   // ssl: true
   // tls: true
@@ -56,7 +57,6 @@ config.mongodb.writeOptions = {
     w: 'majority',
     j: true,
   },
-  forceServerObjectId: true,
 };
 
 config.mongodb.requirements = {};

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,7 +61,7 @@ config.mongodb.writeOptions = {
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string
-config.mongodb.requirements.serverVersion = '>=4.2';
+config.mongodb.requirements.serverVersion = '>=4.4';
 
 // this is used by _createUser to add a user as an admin to a collection
 // config.mongodb.collection = 'admin-collection';

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -48,6 +48,11 @@ if(process.env.MONGODB_PASSWORD) {
   config.mongodb.password = process.env.MONGODB_PASSWORD;
 }
 
+if(process.env.MONGODB_SERVER_VERSION) {
+  config.mongodb.requirements.serverVersion =
+    process.env.MONGODB_SERVER_VERSION;
+}
+
 //config.mongodb.connectOptions.loggerLevel = 'debug';
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];


### PR DESCRIPTION
1. Removes the roles check for `./lib/authn.js`
2. Throws if the server version is less than 3.6.0 (this was tested and was the lowest mongo node 4 goes)
3. Ups the default server version to 4.4


TODO:

- [x] Test with mongodb server v3
- [x] Test with mongodb server v2

Node Driver compatibility matrix is here: https://www.mongodb.com/docs/drivers/node/current/compatibility/#mongodb-compatibility

3.6 seems to be the lowest. 