### PR TITLE
Remove defaults for writeOptions from config.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -43,8 +43,7 @@ config.mongodb.connectOptions = {
   // promotes binary BSON values to native Node.js buffers
   promoteBuffers: true,
   forceServerObjectId: true,
-  // it is recommended to set either ssl or tls to true in production
-  // ssl: true
+  // it is recommended to set tls to true in production
   // tls: true
   // authSource is the database you authenticate against
   // it often needs to be set explicitly
@@ -52,12 +51,7 @@ config.mongodb.connectOptions = {
 };
 
 // this is used when writing to the database
-config.mongodb.writeOptions = {
-  writeConcern: {
-    w: 'majority',
-    j: true,
-  },
-};
+config.mongodb.writeOptions = {};
 
 config.mongodb.requirements = {};
 // server version requirement with server-style string


### PR DESCRIPTION
Removes the default write options.

- `writeConcern` defaults to undefined now

Addresses: https://github.com/digitalbazaar/bedrock-mongodb/issues/51

Additionally it turns out this fixes an issue with node mongo driver 4:

```
  error: MongoInvalidArgumentError: Option "explain" cannot be used on an aggregate call with writeConcern
```

You can not use `explain` if `writeConcern` was added an option. This was tested and with node mongo driver 3 you can have `explain` with `writeConcern`, but you can not with node mongo driver 4. Hence this PR now is a necessary feature in the upgrade.