### PR TITLE
Remove deprecated index option background from createIndexes.

### DIFF
--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -218,7 +218,7 @@ describe('api', function() {
         await database.createIndexes([{
           collection: 'test',
           fields: {id: 1},
-          options: {unique: true, background: false}
+          options: {unique: true}
         }]);
       } catch(e) {
         error = e;
@@ -386,7 +386,7 @@ describe('api', function() {
       await database.createIndexes([{
         collection: 'test',
         fields: {id: 1},
-        options: {unique: true, background: false}
+        options: {unique: true}
       }]);
     });
     it('should have collections', async function() {


### PR DESCRIPTION
Removes the usage of `background` from test project.

Addresses: https://github.com/digitalbazaar/bedrock-mongodb/issues/70