### PR TITLE
Remove deprecated option adminPrompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **BREAKING**: Upgrade to `mongodb: ^4.9.0`
 
 ### Removed
-- Remove `config.adminPrompt`.
+- Remove unused `config.adminPrompt`.
 
 ## 10.1.1 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **BREAKING**: Upgrade to `mongodb: ^4.9.0`
 
+### Removed
+- Remove `config.adminPrompt`.
+
 ## 10.1.1 -
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bedrock.config.mongodb.username = 'my_project'; // default: bedrock
 bedrock.config.mongodb.password = 'password';   // default: password
 
 // the mongodb database 'my_project_dev' and the 'my_project' user will
-// be created on start up following a prompt for the admin user credentials
+// be created on start up.
 
 // alternatively, use `mongodb` URL format:
 bedrock.config.mongodb.url = 'mongodb://localhost:27017/my_project_dev';
@@ -106,6 +106,7 @@ config.mongodb.url = 'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.
    for your version of MongoDB. Version 4.2.x is currently supported.
 2. [optional] Tweak your project's configuration settings; see
    [Configuration](#configuration) or [Quick Examples](#quickexamples).
+3. Ensure the user for your database and/or collections is setup too.
 
 ## API
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,6 @@ config.mongodb.port = 27017;
 config.mongodb.protocol = 'mongodb';
 config.mongodb.username = undefined;
 config.mongodb.password = undefined;
-config.mongodb.adminPrompt = true;
 // always authenticate to mongodb even when auth is not required by mongodb
 config.mongodb.forceAuthentication = false;
 config.mongodb.authentication = {
@@ -62,6 +61,3 @@ config.mongodb.writeOptions = {
 config.mongodb.requirements = {};
 // server version requirement with server-style string
 config.mongodb.requirements.serverVersion = '>=4.2';
-
-// this is used by _createUser to add a user as an admin to a collection
-// config.mongodb.collection = 'admin-collection';

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -6,7 +6,6 @@ import {config} from '@bedrock/core';
 config.mongodb.name = 'bedrock_test';
 config.mongodb.host = 'localhost';
 config.mongodb.port = 27017;
-config.mongodb.adminPrompt = true;
 
 // these settings are only effective if `test` is specified on the command line
 // when onInit = true, collections are dropped on initialization


### PR DESCRIPTION
This removes `adminPrompt` which used to pause bedrock if the user for the database wasn't found.
It would then ask for the admin user and password and then add users to the database. `adminPrompt` was deprecated at some point in a previous major release, but the config option wasn't removed. So this PR is basically clean up.