### PR TITLE
Fix README link.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 
 root = true
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ bedrock.config.mongodb.dropCollections.collections = [];
 
 [Apache License, Version 2.0](LICENSE) Copyright 2011-2024 Digital Bazaar, Inc.
 
-Additional Bedrock libraries are available for non-commercial use such as
-self-study, research, personal projects, or for evaluation purposes. See the
-[Bedrock Non-Commercial License v1.0](https://github.com/digitalbazaar/bedrock/LICENSES/LicenseRef-Bedrock-NC-1.0.txt)
+Other Bedrock libraries are available under a non-commercial license for uses
+such as self-study, research, personal projects, or for evaluation purposes.
+See the
+[Bedrock Non-Commercial License v1.0](https://github.com/digitalbazaar/bedrock/blob/main/LICENSES/LicenseRef-Bedrock-NC-1.0.txt)
 for details.
 
 Commercial licensing and support are available by contacting


### PR DESCRIPTION
- Use updated README license section.
- Add `s` to URL in .editorconfig.
