### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TAGS
 coverage
 node_modules
 reports
+package-lock.json


### PR DESCRIPTION
- Use updated README license section.
- Add `s` to URL in .editorconfig.
- Ignore package-lock.json.
