### PR TITLE
Coerce non standard version strings when checking mongo server version.

### DIFF
--- a/lib/authn.js
+++ b/lib/authn.js
@@ -17,10 +17,10 @@
  */
 import * as bedrock from '@bedrock/core';
 import * as urls from './urls.js';
+import {satisfies, coerce} from 'semver';
 import {logger} from './logger.js';
 import {MDBE_AUTHZ_FAILED} from './exceptions.js';
 import mongo from 'mongodb';
-import semver from 'semver';
 
 const {MongoClient} = mongo;
 const {util: {BedrockError}} = bedrock;
@@ -174,7 +174,7 @@ function _checkServerVersion({serverInfo, config}) {
     version,
   });
   if(config.requirements.serverVersion &&
-    !semver.satisfies(version, config.requirements.serverVersion)) {
+    !satisfies(coerce(version), config.requirements.serverVersion)) {
     throw new BedrockError('Unsupported database version.', {
       name: 'VersionError',
       details: {


### PR DESCRIPTION
Handles instances where mongo returns a 'non standard' version string. 

A scenario where this could occur is when using Percona Server for MongoDB, which for Mongo 8 currently reports its version as `8.0.12-4`. When a bedrock application starts this causes an error in the server version check.

```json
{
  "name": "VersionError",
  "message": "Unsupported database version.",
  "details": {
    "url": "mongodb://...",
    "version": "8.0.12-4",
    "required": ">=5"
  },
  "cause": null
}
```

This behavior is described in the node-semver [documentation](https://github.com/npm/node-semver?tab=readme-ov-file#prerelease-tags).

This PR attempts to resolve this by parsing a standard semver version from the version string returned by mongo using the semver [coercion](https://github.com/npm/node-semver?tab=readme-ov-file#coercion) logic.

Alternatviely the `includePrerelease` [option](https://github.com/npm/node-semver?tab=readme-ov-file#functions) could be added to achieve the same behavior as introduced in this PR.

```js
if(config.requirements.serverVersion &&
  !semver.satisfies(version, config.requirements.serverVersion,  {includePrerelease: true})) {
  ...
}
```

